### PR TITLE
Make /docs consistent with docstring edits

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,10 +13,10 @@ servers.
 
 Using a tool in Toolchest is as simple as:
 
-    >>> import toolchest_client as tc
-    >>> tc.set_key(YOUR_TOOLCHEST_KEY)
-    >>> tc.cutadapt(
-    ...     YOUR_CUSTOM_TOOL_ARGS,
+    >>> import toolchest_client as toolchest
+    >>> toolchest.set_key("YOUR_TOOLCHEST_KEY")
+    >>> toolchest.cutadapt(
+    ...     tool_args="YOUR_CUSTOM_TOOL_ARGS",
     ...     input_path="path/to/input",
     ...     output_path="path/to/output",
     ... )

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -26,8 +26,8 @@ Contact Toolchest if:
 
 Once you have an authentication key, configure your client as follows:
 
-    >>> import toolchest_client as tc
-    >>> tc.set_key(YOUR_TOOLCHEST_KEY)
+    >>> import toolchest_client as toolchest
+    >>> toolchest.set_key(YOUR_TOOLCHEST_KEY)
 
 The variable `YOUR_TOOLCHEST_KEY` can be either a string containing your
 key or a path to a file containing the key (and nothing else).
@@ -43,9 +43,9 @@ command line:
 Once Toolchest is configured, you can do the same with the corresponding
 Toolchest function:
 
->>> import toolchest_client as tc
->>> tc.your_tool(
-...     YOUR_CUSTOM_TOOL_ARGS,
+>>> import toolchest_client as toolchest
+>>> toolchest.your_tool(
+...     tool_args="YOUR_CUSTOM_TOOL_ARGS",
 ...     input_path="path/to/input",
 ...     output_path="path/to/output",
 ... )


### PR DESCRIPTION
Updates `/docs` files to be consistent with edits made to docstrings in PR #2 