### PR TITLE
Add basic CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             PYPI_ENVIRONMENT=$([[ $CIRCLE_BRANCH = main ]] && echo pypi || echo testpypi)
             PYPI_ACCESS_TOKEN=$([[ $PYPI_ENVIRONMENT = pypi ]] && echo $PYPI_PROD_TOKEN || echo $PYPI_TEST_TOKEN)
             poetry config pypi-token.$PYPI_ENVIRONMENT $PYPI_ACCESS_TOKEN
-            poetry publish --build -r $DEPLOY_ENVIRONMENT
+            poetry publish --build -r $PYPI_ENVIRONMENT
 workflows:
   deploy:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2.1
+orbs:
+  python: circleci/python@1.4.0
+jobs:
+  deploy-to-pypi:
+    executor: python/default
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: poetry
+      - run:
+          name: Build and publish to PyPI
+          command: |
+            cd ~/repo
+            PYPI_ENVIRONMENT=$([[ $CIRCLE_BRANCH = main ]] && echo pypi || echo testpypi)
+            PYPI_ACCESS_TOKEN=$([[ $PYPI_ENVIRONMENT = pypi ]] && echo $PYPI_PROD_TOKEN || echo $PYPI_TEST_TOKEN)
+            poetry config pypi-token.$PYPI_ENVIRONMENT $PYPI_ACCESS_TOKEN
+            poetry publish --build -r $DEPLOY_ENVIRONMENT
+workflows:
+  deploy:
+    jobs:
+      - deploy-to-pypi:
+          filters:
+            branches:
+              only:
+                - main
+                - staging
+                - feature/circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
 jobs:
   deploy-to-pypi:
     executor: python/default
+    working_directory: ~/repo
     steps:
       - checkout
       - python/install-packages:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.4.0"
+version = "0.3.0"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",


### PR DESCRIPTION
Adds a basic CircleCI config. We'll also want to add lint and tests to CircleCI later.

Adds:
- Automatic deployment of builds to PyPI. `staging` deploys to TestPyPI (tested), and `main` deploys to normal PyPI (untested).