### PR TITLE
Add test pipeline segment

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -23,6 +23,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "python-dotenv"
+version = "0.18.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "requests"
 version = "2.25.1"
 description = "Python HTTP for Humans."
@@ -56,7 +67,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "ae6e040f5a7499f657a2424ae60a1a0658fdd5d79b6e3267323f643309b1245c"
+content-hash = "8266ead3e21dcfd6a24d482df5308cef7b451df521dc3e4cd3168e586da06726"
 
 [metadata.files]
 certifi = [
@@ -70,6 +81,10 @@ chardet = [
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.18.0.tar.gz", hash = "sha256:effaac3c1e58d89b3ccb4d04a40dc7ad6e0275fda25fd75ae9d323e2465e202d"},
+    {file = "python_dotenv-0.18.0-py2.py3-none-any.whl", hash = "sha256:dd8fe852847f4fbfadabf6183ddd4c824a9651f02d51714fa075c95561959c7d"},
 ]
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.6"
 requests = "^2.25.1"
+python-dotenv = "^0.18.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -8,4 +8,4 @@ load_dotenv(find_dotenv(".env"))
 from .auth import get_key, set_key
 from .exceptions import ToolchestException, DataLimitError
 from .query import Query
-from .tools import bowtie2, cutadapt, kraken2, run_tool
+from .tools import bowtie2, cutadapt, kraken2, test, run_tool

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -1,6 +1,13 @@
 # TODO: include a docstring here
 
+from dotenv import load_dotenv, find_dotenv, dotenv_values
+
+# .env load must be before imports that use environment variables
+load_dotenv(find_dotenv(".env"))
+
 from .auth import get_key, set_key
 from .exceptions import ToolchestException, DataLimitError
 from .query import Query
 from .tools import cutadapt, kraken2, run_tool
+
+

--- a/toolchest_client/query.py
+++ b/toolchest_client/query.py
@@ -25,7 +25,7 @@ class Query():
     """
 
     # Base URLs used by the server API.
-    BASE_URL = "https://api.toolche.st"
+    BASE_URL = os.environ.get("BASE_URL", "https://api.toolche.st")
     PIPELINE_ROUTE = "/pipeline-segment-instances"
     PIPELINE_URL = BASE_URL + PIPELINE_ROUTE
 

--- a/toolchest_client/tools.py
+++ b/toolchest_client/tools.py
@@ -9,6 +9,7 @@ from ._internal_utils import _validate_tool_kwargs
 from .query import Query
 from .version import Version
 
+
 def run_tool(tool, version, **kwargs):
     """Constructs and runs a Toolchest query.
 
@@ -23,6 +24,7 @@ def run_tool(tool, version, **kwargs):
 
     q = Query()
     q.run_query(tool, version, **kwargs)
+
 
 def bowtie2(tool_args="", **kwargs):
     """Runs Bowtie 2 (for alignment) via Toolchest.
@@ -117,6 +119,34 @@ def kraken2(tool_args="", **kwargs):
         Version.KRAKEN2.value,
         tool_args=tool_args,
         input_name="input.fastq",
+        output_name="output.txt",
+        **kwargs
+    )
+
+
+def test(tool_args="", **kwargs):
+    """Run a test pipeline segment via Toolchest. A plain text file containing 'step one' is returned."
+
+    :param tool_args: Additional arguments, present to maintain a consistent interface. This is disregarded.
+    :param input_path: Path (client-side) of file to be passed in as input.
+    :param output_path: Path (client-side) where the output file will be downloaded.
+
+    Usage::
+
+        >>> import toolchest_client as toolchest
+        >>> toolchest.test(
+        ...     input_path="./path/to/input.txt",
+        ...     output_path="./path/to/output.txt",
+        ... )
+
+    """
+
+    _validate_tool_kwargs(**kwargs)
+    run_tool(
+        "test",
+        Version.TEST.value,
+        tool_args=tool_args,
+        input_name="input.txt",
         output_name="output.txt",
         **kwargs
     )

--- a/toolchest_client/version.py
+++ b/toolchest_client/version.py
@@ -13,3 +13,4 @@ class Version(Enum):
     BOWTIE2 = "2.4.4"
     CUTADAPT = "3.4"
     KRAKEN2 = "2.1.1"
+    TEST = "0.1.0"


### PR DESCRIPTION
Adds a `test` pipeline segment.

Adds:
- `test` pipeline segment to allow demonstrating/trying out the interface without a specific tool to distract.
- `.env` handling with `python-dotenv`