### PR TITLE
Override built-in print statement to flush after every print

### DIFF
--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -1,9 +1,14 @@
 # TODO: include a docstring here
 
+import builtins
 from dotenv import load_dotenv, find_dotenv
+import functools
 
 # .env load must be before imports that use environment variables
 load_dotenv(find_dotenv(".env"))
+
+# specifying print flushing is necessary to support loading from R
+builtins.print = functools.partial(print, flush=True)
 
 from .auth import get_key, set_key
 from .exceptions import ToolchestException, DataLimitError


### PR DESCRIPTION
Adds:
- Support for consistent buffer flushing. This allows consistent output when loaded in R via `reticulate`

