### PR TITLE
Add detection of errors in master/worker nodes to client

### DIFF
--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -11,6 +11,6 @@ load_dotenv(find_dotenv(".env"))
 builtins.print = functools.partial(print, flush=True)
 
 from .auth import get_key, set_key
-from .exceptions import ToolchestException, DataLimitError
+from .exceptions import ToolchestException, DataLimitError, ToolchestJobError
 from .query import Query
 from .tools.api import bowtie2, cutadapt, kraken2, test, unicycler

--- a/toolchest_client/exceptions.py
+++ b/toolchest_client/exceptions.py
@@ -12,3 +12,6 @@ class ToolchestException(OSError):
 
 class DataLimitError(ToolchestException):
     """Data limit for Toolchest exceeded."""
+
+class ToolchestJobError(ToolchestException):
+    """An error occurred when running the job instance."""

--- a/toolchest_client/query.py
+++ b/toolchest_client/query.py
@@ -183,14 +183,14 @@ class Query():
 
         self._update_status(Status.TRANSFERRED_FROM_CLIENT)
 
-    def _update_status(self, new_status, additional_params=None):
+    def _update_status(self, new_status, extra_params=None):
         """Updates the internal status of the query's task(s).
 
         Returns the response from the PUT request.
         """
         update_json = {"status": new_status}
-        if additional_params:
-            update_json.update(additional_params)
+        if extra_params:
+            update_json.update(extra_params)
 
         response = requests.put(
             self.STATUS_URL,

--- a/toolchest_client/query.py
+++ b/toolchest_client/query.py
@@ -306,7 +306,7 @@ class Query():
             with open(output_path, "wb") as f:
                 for chunk in r.iter_content(chunk_size=8192):
                     f.write(chunk)
-            # TODO: catch errors when writing
+            # TODO: output more detailed error message if write error encountered
 
         self._update_status(Status.TRANSFERRED_TO_CLIENT)
 

--- a/toolchest_client/query.py
+++ b/toolchest_client/query.py
@@ -282,6 +282,7 @@ class Query():
         except HTTPError:
             print("Job status retrieval failed.")
             self._raise_for_failed_job(response)
+            # Assumes that job status has been set to failed if response status code is NOT OK.
             return Status.FAILED
 
         return response.json()["status"]

--- a/toolchest_client/query.py
+++ b/toolchest_client/query.py
@@ -161,7 +161,7 @@ class Query():
     def _upload(self, input_file_paths, input_prefix_mapping):
         """Uploads the files at ``input_file_paths`` to Toolchest."""
 
-        self._update_status(Status.TRANSFERRING_FROM_CLIENT.value)
+        self._update_status(Status.TRANSFERRING_FROM_CLIENT)
 
         for file_path in input_file_paths:
             print(f"Uploading {file_path}")
@@ -179,7 +179,7 @@ class Query():
             except HTTPError:
                 self._raise_for_failed_client(f"Input file upload failed for file at {file_path}.")
 
-        self._update_status(Status.TRANSFERRED_FROM_CLIENT.value)
+        self._update_status(Status.TRANSFERRED_FROM_CLIENT)
 
     def _update_status(self, new_status, additional_params=None):
         """Updates the internal status of the query's task(s).
@@ -214,7 +214,7 @@ class Query():
         It is not invoked if the query is not noted internally (i.e., an error
         is caught before the initial request to the API is sent).
         """
-        self._update_status(Status.FAILED.value, {"error_message": error_message})
+        self._update_status(Status.FAILED, {"error_message": error_message})
         if force_raise:
             raise ToolchestException(error_message) from None
         else:
@@ -251,7 +251,7 @@ class Query():
         """Waits for query task(s) to finish executing."""
         status = self._get_job_status()
         start_time = time.time()
-        while status != Status.READY_TO_TRANSFER_TO_CLIENT.value:
+        while status != Status.READY_TO_TRANSFER_TO_CLIENT:
             status = self._get_job_status()
 
             elapsed_time = time.time() - start_time
@@ -281,7 +281,7 @@ class Query():
 
         download_signed_url = self._get_download_signed_url()
 
-        self._update_status(Status.TRANSFERRING_TO_CLIENT.value)
+        self._update_status(Status.TRANSFERRING_TO_CLIENT)
 
         # Dowloads output by sending a GET request.
         with requests.get(download_signed_url, stream=True) as r:
@@ -297,7 +297,7 @@ class Query():
                     f.write(chunk)
             # TODO: catch errors when writing
 
-        self._update_status(Status.TRANSFERRED_TO_CLIENT.value)
+        self._update_status(Status.TRANSFERRED_TO_CLIENT)
 
     def _get_download_signed_url(self):
         """Gets URL for downloading output of query task(s)."""
@@ -322,7 +322,7 @@ class Query():
         # otherwise, each Query instance persists until exit
 
         status = self._get_job_status()
-        if status != Status.TRANSFERRED_TO_CLIENT.value:
+        if status != Status.TRANSFERRED_TO_CLIENT:
             self._raise_for_failed_client(
                 "Client exited before job completion.",
                 force_raise=False,

--- a/toolchest_client/query.py
+++ b/toolchest_client/query.py
@@ -331,7 +331,7 @@ class Query():
         # TODO: look at putting this function inside the __init__?
         # otherwise, each Query instance persists until exit
 
-        if self.STATUS_URL != '' and self.mark_as_failed:
+        if self.mark_as_failed:
             status = self._get_job_status()
             if status != Status.TRANSFERRED_TO_CLIENT and status != Status.FAILED:
                 self._raise_for_failed_client(

--- a/toolchest_client/status.py
+++ b/toolchest_client/status.py
@@ -7,7 +7,7 @@ This module contains a Status class for status updates to the Toolchest API.
 
 from enum import Enum
 
-class Status(Enum):
+class Status(str, Enum):
     """Status values for the Toolchest API."""
 
     INITIALIZED = "initialized"

--- a/toolchest_client/status.py
+++ b/toolchest_client/status.py
@@ -19,3 +19,4 @@ class Status(Enum):
     READY_TO_TRANSFER_TO_CLIENT = "ready_to_transfer_to_client"
     TRANSFERRING_TO_CLIENT = "transferring_to_client"
     TRANSFERRED_TO_CLIENT = "transferred_to_client"
+    FAILED = "failed"


### PR DESCRIPTION
This is facilitated by raising a `ToolchestJobError` if a `NOT OK` status is detected during any status update/check (e.g., while waiting for the job to finish executing, while waiting for downloads, etc.).
This effectively punts the task of distinguishing errors and marking failed jobs to the master/worker node levels. (This is okay because this simplifies the task at hand.)