### PR TITLE
Fix support for Unicycler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.7.1"
+version = "0.7.2"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",


### PR DESCRIPTION
Adds:
- Explicit concept of jobs in Tools to distinguish between Tools which have multiple input files and parallel runs which have multiple split input files.

Fixes support for Unicycler (non-parallel) in v0.7.x.