### PR TITLE
Updates mark_as_failed after download

### DIFF
--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -325,7 +325,6 @@ class Query():
         # otherwise, each Query instance persists until exit
 
         if self.mark_as_failed:
-            status = self._get_job_status()
             self._update_status_to_failed(
                 "Client exited before job completion.",
             )


### PR DESCRIPTION
Updates `mark_as_failed` to `False` after download (to prevent successful jobs from being marked as failed) and deletes extraneous `mark_as_failed` updates.