### PR TITLE
Key validation restructuring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.7.13"
+version = "0.7.14"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/toolchest_client/api/auth.py
+++ b/toolchest_client/api/auth.py
@@ -7,6 +7,12 @@ This module contains functions for configuring the Toolchest API key.
 """
 
 import os
+import sys
+
+import requests
+from requests.exceptions import HTTPError
+
+from toolchest_client.api.exceptions import ToolchestKeyError
 
 
 def get_key():
@@ -41,4 +47,20 @@ def set_key(key):
     else:
         os.environ["TOOLCHEST_KEY"] = key
 
-# TODO: implement key validation
+
+def _validate_key():
+    """Validates Toolchest API key, retrieved from get_key()."""
+
+    BASE_URL = os.environ.get("BASE_URL", "https://api.toolche.st")
+    HEADERS = {"Authorization": f"Key {get_key()}"}
+
+    validation_response = requests.get(
+        BASE_URL,
+        headers=HEADERS,
+    )
+    try:
+        validation_response.raise_for_status()
+    except HTTPError:
+        error_message = "Invalid Toolchest auth key. Please check the key value or contact Toolchest."
+        print(error_message, file=sys.stderr)
+        raise ToolchestKeyError(error_message) from None

--- a/toolchest_client/api/exceptions.py
+++ b/toolchest_client/api/exceptions.py
@@ -12,6 +12,10 @@ class ToolchestException(OSError):
     """
 
 
+class ToolchestKeyError(ToolchestException):
+    """Invalid Toolchest auth key."""
+
+
 class DataLimitError(ToolchestException):
     """Data limit for Toolchest exceeded."""
 

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -67,17 +67,8 @@ class Query():
         self.thread_statuses = thread_statuses
         self._check_if_should_terminate()
 
-        # Retrieve and validate Toolchest auth key.
+        # Configure Toolchest auth key.
         self.HEADERS["Authorization"] = f"Key {get_key()}"
-        validation_response = requests.get(
-            self.BASE_URL,
-            headers=self.HEADERS,
-        )
-        try:
-            validation_response.raise_for_status()
-        except HTTPError:
-            print("Invalid Toolchest auth key. Please check the key value or contact Toolchest.", file=sys.stderr)
-            raise
 
         # Create pipeline segment and task(s).
         # Retrieve query ID and upload URL from initial response.

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -13,6 +13,7 @@ import sys
 from threading import Thread
 import time
 
+from toolchest_client.api.auth import _validate_key
 from toolchest_client.api.exceptions import ToolchestException
 from toolchest_client.api.status import ThreadStatus
 from toolchest_client.api.query import Query
@@ -236,6 +237,10 @@ class Tool:
     def run(self):
         """Constructs and runs a Toolchest query."""
         print("Beginning Toolchest analysis run.")
+
+        # Validate Toolchest auth key.
+        _validate_key()
+
         # todo: better propagate and handle errors for parallel runs
         self._validate_args()
 


### PR DESCRIPTION
Adds `_validate_key()` to `auth.py` and moves the key validation check from `Query.run_query()` to `Tool.run()`, where it occurs before any jobs are spawned.

Note that any invalid key checks can take as long as a minute. The key validity is determined to be invalid by the API, which hangs and eventually times out upon encountering an invalid key. We'll need to make a change to the API to speed this up as well.