### PR TITLE
Fixes single "read_one" Kraken 2 bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.7.19"
+version = "0.7.20"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -107,8 +107,10 @@ def kraken2(output_path, inputs=[], database_name="standard", database_version="
 
     """
 
-    if read_one and read_two:
-        inputs = [read_one, read_two]
+    if read_one:
+        inputs = [read_one]
+    if read_two:
+        inputs.append(read_two)
 
     # Add --paired tag if paired reads are provided. Else, remove if present.
     tool_args_list = tool_args.split()


### PR DESCRIPTION
Fixes a bug that would incorrectly flag Kraken 2 called with one arg – `read_one` – as containing zero input files. 