### PR TITLE
Limit on S3 URI input size

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.7.31"
+version = "0.7.32"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/toolchest_client/files/general.py
+++ b/toolchest_client/files/general.py
@@ -32,19 +32,22 @@ def assert_exists(path, must_be_file=False, must_be_directory=False):
         raise ValueError(f"Directory entry at {path} is not a directory")
 
 
-def check_file_size(file_path, max_size_bytes=None, is_s3_uri=False):
+def check_file_size(file_path, max_size_bytes=None, file_is_in_s3=False):
     """Raises an error if the file is above the non-multipart upload limit for S3 (5GB)
 
     :param file_path: A path to a file.
     :type file_path: string
     :param max_size_bytes: Maximum number of bytes allowed for a file. Throws error if above limit.
     :type max_size_bytes: int | None
+    :param file_is_in_s3: Whether or not the file path is an S3 URI, as opposed to a local filepath.
+    :type file_is_in_s3: bool
     """
-    if not is_s3_uri:
+    if not file_is_in_s3:
         assert_exists(file_path, must_be_file=True)
         file_size_bytes = os.stat(file_path).st_size
     else:
         # Get file size S3 metadata, via boto3.
+        # NOTE: It's best to move this to
         s3_file_params = get_params_from_s3_uri(file_path)
         s3_client = boto3.client("s3")
         response = s3_client.head_object(

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -289,9 +289,8 @@ class Tool:
         else:
             # Make sure we're below plan/multi-part limit for non-splittable files
             for file_path, file_is_in_s3 in zip(self.input_files, self.inputs_are_in_s3):
-                if not file_is_in_s3:
-                    check_file_size(file_path, max_size_bytes=FOUR_POINT_FIVE_GIGABYTES)
-                # If the file is already in S3, no need to check max size.
+                check_file_size(file_path, max_size_bytes=FOUR_POINT_FIVE_GIGABYTES, is_s3_uri=file_is_in_s3)
+                # If the file is already in S3, the size is checked in check_file_size as well.
             # Note that for a tool like Unicycler, this would look like:
             # [["r1.fastq", "r2.fastq", "unassembled.fasta"]]
             # As there are multiple input files required for the job

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -288,9 +288,9 @@ class Tool:
 
         else:
             # Make sure we're below plan/multi-part limit for non-splittable files
+            # NOTE: If the file is already in S3, the size is checked as well to enforce an expected file size
             for file_path, file_is_in_s3 in zip(self.input_files, self.inputs_are_in_s3):
-                check_file_size(file_path, max_size_bytes=FOUR_POINT_FIVE_GIGABYTES, is_s3_uri=file_is_in_s3)
-                # If the file is already in S3, the size is checked in check_file_size as well.
+                check_file_size(file_path, max_size_bytes=FOUR_POINT_FIVE_GIGABYTES, file_is_in_s3=file_is_in_s3)
             # Note that for a tool like Unicycler, this would look like:
             # [["r1.fastq", "r2.fastq", "unassembled.fasta"]]
             # As there are multiple input files required for the job


### PR DESCRIPTION
Adds a check on the size of an input provided as an S3 URI, as a safeguard. The limit is the same as the size of a user-uploaded file (4.5 GB).

Note: This limit will be removed once multipart uploads are implemented for client-uploaded inputs (so that the behavior of the limts for S3 URI inputs matches), though we may want to increase the size of the limit rather than remove it altogether.