### PR TITLE
Fix boto3 install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ packages = [
 "Bug Tracker" = "https://github.com/trytoolchest/toolchest-client-python/issues"
 
 [tool.poetry.dependencies]
+boto3 = "^1.18.29"
 python = "^3.6"
 requests = "^2.25.1"
 python-dotenv = "^0.18.0"
@@ -31,7 +32,6 @@ importlib-metadata = { version = "~=1.0", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"
-boto3 = "^1.18.29"
 
 [[tool.poetry.source]]
 name = "pypi-public"


### PR DESCRIPTION
Modifies:
- `boto3` install, so that it's a normal dependency rather than a dev dependency