### PR TITLE
Increase test tool limit to 256 GB

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.7.34"
+version = "0.7.35"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/toolchest_client/tools/test.py
+++ b/toolchest_client/tools/test.py
@@ -21,4 +21,5 @@ class Test(Tool):
             inputs=inputs,
             min_inputs=1,
             max_inputs=100,  # this limit is completely arbitrary
+            max_input_bytes_per_node=256 * 1024 * 1024 * 1024,
         )


### PR DESCRIPTION
Modifies:
- Test tool per-file limit from 4.5 GB (default) to 256 GB