### PR TITLE
Cleanup for v0.7.37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.7.36"
+version = "0.7.37"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -58,7 +58,7 @@ def test_star_grch38_parallel():
     )
 
     # Because STAR is non-deterministic, verify that the number of bytes is in range
-    assert 33292992706 <= os.path.getsize(output_file_path) <= 33292992730
+    assert 33292990718 <= os.path.getsize(output_file_path) <= 33292994718
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Modifies:
- Version number
- Range for parallel STAR integration test to manage the leeway given to a smaller non-parallel integration test