### PR TITLE
Propagate order of inputs within tool arg prefix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.7.43"
+version = "0.7.44"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -50,7 +50,7 @@ class Query():
         self.thread_name = ''
         self.thread_statuses = None
 
-    def run_query(self, tool_name, tool_version, input_prefix_mapping,
+    def run_query(self, tool_name, tool_version, input_prefix_mapping, input_prefix_order,
                   output_type, tool_args=None, database_name=None, database_version=None,
                   output_name="output", input_files=None,
                   output_path=None, thread_statuses=None):
@@ -61,6 +61,8 @@ class Query():
         :param tool_args: Tool-specific arguments to be passed to the tool.
         :param database_name: Name of database to be used.
         :param database_version: Version of database to be used.
+        :param input_prefix_mapping: Mapping of input filepaths to associated prefix tags (e.g., "-1")
+        :param input_prefix_order: Mapping of input filepaths to their order under the respective prefix tag, 0-indexed
         :param output_name: (optional) Internal name of file outputted by the tool.
         :param input_files: List of paths to be passed in as input.
         :param output_path: Path (client-side) where the output file will be downloaded.
@@ -102,7 +104,7 @@ class Query():
 
         self._check_if_should_terminate()
         self._update_thread_status(ThreadStatus.UPLOADING)
-        self._upload(input_files, input_prefix_mapping)
+        self._upload(input_files, input_prefix_mapping, input_prefix_order)
         self._check_if_should_terminate()
 
         self._update_thread_status(ThreadStatus.EXECUTING)
@@ -146,7 +148,7 @@ class Query():
 
     # Note: input_is_in_s3 is False by default for backwards compatibility.
     # TODO: Deprecate this after confirming it doesn't affect the API.
-    def _add_input_file(self, input_file_path, input_prefix, input_is_in_s3=False):
+    def _add_input_file(self, input_file_path, input_prefix, input_prefix_order, input_is_in_s3=False):
         add_input_file_url = "/".join([
             self.PIPELINE_SEGMENT_URL,
             'input-files'
@@ -159,6 +161,7 @@ class Query():
             json={
                 "file_name": file_name,
                 "tool_prefix": input_prefix,
+                "tool_prefix_order": input_prefix_order,
                 "is_s3": input_is_in_s3,
                 "s3_uri": input_file_path if input_is_in_s3 else "",
             },
@@ -179,7 +182,7 @@ class Query():
                 "object_name": response_json.get('object_name'),
             }
 
-    def _upload(self, input_file_paths, input_prefix_mapping):
+    def _upload(self, input_file_paths, input_prefix_mapping, input_prefix_order):
         """Uploads the files at ``input_file_paths`` to Toolchest."""
 
         self._update_status(Status.TRANSFERRING_FROM_CLIENT)
@@ -193,6 +196,7 @@ class Query():
                 self._add_input_file(
                     input_file_path=file_path,
                     input_prefix=input_prefix_mapping.get(file_path),
+                    input_prefix_order=input_prefix_order.get(file_path),
                     input_is_in_s3=input_is_in_s3,
                 )
             else:
@@ -200,6 +204,7 @@ class Query():
                 input_file_keys = self._add_input_file(
                     input_file_path=file_path,
                     input_prefix=input_prefix_mapping.get(file_path),
+                    input_prefix_order=input_prefix_order.get(file_path),
                     input_is_in_s3=input_is_in_s3,
                 )
 

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -189,7 +189,9 @@ class Query():
         S3_PREFIX = "s3://"
         for file_path in input_file_paths:
             input_is_in_s3 = file_path.startswith(S3_PREFIX)
-            input_prefix, input_order = input_prefix_mapping.get(file_path, (None, None))
+            input_prefix_details = input_prefix_mapping.get(file_path)
+            input_prefix = input_prefix_details.get("prefix")
+            input_order = input_prefix_details.get("order")
             # If the file is already in S3, there is no need to upload.
             if input_is_in_s3:
                 # Registers the file in the internal DB.

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -171,11 +171,13 @@ def megahit(output_path, tool_args="", read_one=None, read_two=None, interleaved
     }
     input_list = []  # list of all inputs
     input_prefix_mapping = {}  # map of each input to its respective tag
+    input_prefix_order = {}  # map of each input to its respective order in the prefix arg
     for tag, param in tag_to_param_map.items():
         if isinstance(param, list):
-            for input_file in param:
+            for index, input_file in enumerate(param):
                 input_list.append(input_file)
                 input_prefix_mapping[input_file] = tag
+                input_prefix_order[input_file] = index
         elif isinstance(param, str):
             input_list.append(param)
             input_prefix_mapping[param] = tag
@@ -184,6 +186,7 @@ def megahit(output_path, tool_args="", read_one=None, read_two=None, interleaved
         tool_args=tool_args,
         output_name='output.tar.gz',
         input_prefix_mapping=input_prefix_mapping,
+        input_prefix_order=input_prefix_order,
         inputs=input_list,
         output_path=output_path,
     )

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -171,13 +171,14 @@ def megahit(output_path, tool_args="", read_one=None, read_two=None, interleaved
     }
     input_list = []  # list of all inputs
     input_prefix_mapping = {}  # map of each input to its respective tag
-    input_prefix_order = {}  # map of each input to its respective order in the prefix arg
     for tag, param in tag_to_param_map.items():
         if isinstance(param, list):
             for index, input_file in enumerate(param):
                 input_list.append(input_file)
-                input_prefix_mapping[input_file] = tag
-                input_prefix_order[input_file] = index
+                input_prefix_mapping[input_file] = {
+                    "prefix": tag,
+                    "order": index,
+                }
         elif isinstance(param, str):
             input_list.append(param)
             input_prefix_mapping[param] = tag
@@ -186,7 +187,6 @@ def megahit(output_path, tool_args="", read_one=None, read_two=None, interleaved
         tool_args=tool_args,
         output_name='output.tar.gz',
         input_prefix_mapping=input_prefix_mapping,
-        input_prefix_order=input_prefix_order,
         inputs=input_list,
         output_path=output_path,
     )

--- a/toolchest_client/tools/megahit.py
+++ b/toolchest_client/tools/megahit.py
@@ -14,7 +14,7 @@ class Megahit(Tool):
     The megahit implementation of the Tool class.
     """
     def __init__(self, tool_args, output_name, inputs, input_prefix_mapping,
-                 input_prefix_order, output_path):
+                 output_path):
         super().__init__(
             tool_name="megahit",
             tool_version="1.2.9",  # todo: allow version to be set by the user
@@ -23,7 +23,6 @@ class Megahit(Tool):
             output_path=output_path,
             inputs=inputs,
             input_prefix_mapping=input_prefix_mapping,
-            input_prefix_order=input_prefix_order,
             min_inputs=1,
             max_inputs=10,  # todo: make this unlimited?
             parallel_enabled=False,

--- a/toolchest_client/tools/megahit.py
+++ b/toolchest_client/tools/megahit.py
@@ -14,7 +14,7 @@ class Megahit(Tool):
     The megahit implementation of the Tool class.
     """
     def __init__(self, tool_args, output_name, inputs, input_prefix_mapping,
-                 output_path):
+                 input_prefix_order, output_path):
         super().__init__(
             tool_name="megahit",
             tool_version="1.2.9",  # todo: allow version to be set by the user
@@ -23,6 +23,7 @@ class Megahit(Tool):
             output_path=output_path,
             inputs=inputs,
             input_prefix_mapping=input_prefix_mapping,
+            input_prefix_order=input_prefix_order,
             min_inputs=1,
             max_inputs=10,  # todo: make this unlimited?
             parallel_enabled=False,

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -30,8 +30,8 @@ class Tool:
     def __init__(self, tool_name, tool_version, tool_args, output_name,
                  output_path, inputs, min_inputs, max_inputs,
                  database_name=None, database_version=None,
-                 input_prefix_mapping=None, parallel_enabled=False,
-                 max_input_bytes_per_file=FOUR_POINT_FIVE_GIGABYTES,
+                 input_prefix_mapping=None, input_prefix_order=None,
+                 parallel_enabled=False, max_input_bytes_per_file=FOUR_POINT_FIVE_GIGABYTES,
                  max_input_bytes_per_file_parallel=FOUR_POINT_FIVE_GIGABYTES,
                  group_paired_ends=False, compress_inputs=False,
                  output_type=OutputType.FLAT_TEXT, output_is_directory=False,
@@ -48,6 +48,7 @@ class Tool:
         #   "./path_to_file.txt": "-prefix",
         # }
         self.input_prefix_mapping = input_prefix_mapping or dict()
+        self.input_prefix_order = input_prefix_order or dict()  # formatted the same as input_prefix_mapping
         self.input_files = None
         self.num_input_files = None
         self.min_inputs = min_inputs
@@ -400,6 +401,7 @@ class Tool:
                 "output_name": f"{index}_{self.output_name}" if should_run_in_parallel else self.output_name,
                 "input_files": input_files,
                 "input_prefix_mapping": self.input_prefix_mapping,
+                "input_prefix_order": self.input_prefix_order,
                 "output_path": temp_parallel_output_file_path if should_run_in_parallel else non_parallel_output_path,
                 "output_type": self.output_type,
             })

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -30,8 +30,8 @@ class Tool:
     def __init__(self, tool_name, tool_version, tool_args, output_name,
                  output_path, inputs, min_inputs, max_inputs,
                  database_name=None, database_version=None,
-                 input_prefix_mapping=None, input_prefix_order=None,
-                 parallel_enabled=False, max_input_bytes_per_file=FOUR_POINT_FIVE_GIGABYTES,
+                 input_prefix_mapping=None, parallel_enabled=False,
+                 max_input_bytes_per_file=FOUR_POINT_FIVE_GIGABYTES,
                  max_input_bytes_per_file_parallel=FOUR_POINT_FIVE_GIGABYTES,
                  group_paired_ends=False, compress_inputs=False,
                  output_type=OutputType.FLAT_TEXT, output_is_directory=False,
@@ -45,10 +45,11 @@ class Tool:
         self.inputs = inputs
         # input_prefix_mapping is a dict in the shape of:
         # {
-        #   "./path_to_file.txt": "-prefix",
+        #   "./path_to_file.txt": {
+        #       "prefix": "-prefix",
+        #       "order": 0,
         # }
         self.input_prefix_mapping = input_prefix_mapping or dict()
-        self.input_prefix_order = input_prefix_order or dict()  # formatted the same as input_prefix_mapping
         self.input_files = None
         self.num_input_files = None
         self.min_inputs = min_inputs
@@ -401,7 +402,6 @@ class Tool:
                 "output_name": f"{index}_{self.output_name}" if should_run_in_parallel else self.output_name,
                 "input_files": input_files,
                 "input_prefix_mapping": self.input_prefix_mapping,
-                "input_prefix_order": self.input_prefix_order,
                 "output_path": temp_parallel_output_file_path if should_run_in_parallel else non_parallel_output_path,
                 "output_type": self.output_type,
             })


### PR DESCRIPTION
Adds:
- Propagation of the order of each input within each tool prefix for `megahit`. This order is 0-indexed and will be passed to the API when uploading/registering each input file. 
 
For example, `read_one = ["input_one", "input_two", "input_three"]` will result in: 
```
  input_prefix_mapping["input_one"]["order"]: 0
  input_prefix_mapping["input_two"]["order"]: 1
  input_prefix_mapping["input_three"]["order"]: 2
```

Note: the order value is stored as the `"order"` parameter within `tool_prefix_mapping`., though it is eventually passed as `tool_prefix_order` to the API.

Requires:
- https://github.com/trytoolchest/toolchest-api/pull/31
- https://github.com/trytoolchest/toolchest-worker-node/pull/30