### PR TITLE
Remove limit on # of input files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.7.46"
+version = "0.7.47"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/toolchest_client/tools/megahit.py
+++ b/toolchest_client/tools/megahit.py
@@ -23,7 +23,7 @@ class Megahit(Tool):
             inputs=inputs,
             input_prefix_mapping=input_prefix_mapping,
             min_inputs=1,
-            max_inputs=10,  # todo: make this unlimited?
+            max_inputs=None,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_is_directory=True,

--- a/toolchest_client/tools/shi7.py
+++ b/toolchest_client/tools/shi7.py
@@ -21,7 +21,7 @@ class Shi7(Tool):
             output_path=output_path,
             inputs=inputs,
             min_inputs=1,
-            max_inputs=10,  # artificially constrained at 10 for now
+            max_inputs=None,  # note: no limit is set on the # of inputs
             parallel_enabled=False,
             group_paired_ends=True,
             max_input_bytes_per_file=5 * 1024 * 1024 * 1024,

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -28,7 +28,7 @@ FOUR_POINT_FIVE_GIGABYTES = int(4.5 * 1024 * 1024 * 1024)
 
 class Tool:
     def __init__(self, tool_name, tool_version, tool_args, output_name,
-                 output_path, inputs, min_inputs, max_inputs,
+                 output_path, inputs, min_inputs, max_inputs=None,
                  database_name=None, database_version=None,
                  input_prefix_mapping=None, parallel_enabled=False,
                  max_input_bytes_per_file=FOUR_POINT_FIVE_GIGABYTES,
@@ -85,7 +85,8 @@ class Tool:
         if self.num_input_files < self.min_inputs:
             raise ValueError(f"Not enough input files submitted. "
                              f"Minimum is {self.min_inputs}, {self.num_input_files} found.")
-        if self.num_input_files > self.max_inputs:
+        # If max_inputs = None, this check is ignored.
+        if self.max_inputs and self.num_input_files > self.max_inputs:
             raise ValueError(f"Too many input files submitted. "
                              f"Maximum is {self.max_inputs}, {self.num_input_files} found.")
 

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -85,7 +85,6 @@ class Tool:
         if self.num_input_files < self.min_inputs:
             raise ValueError(f"Not enough input files submitted. "
                              f"Minimum is {self.min_inputs}, {self.num_input_files} found.")
-        # If max_inputs = None, this check is ignored.
         if self.max_inputs and self.num_input_files > self.max_inputs:
             raise ValueError(f"Too many input files submitted. "
                              f"Maximum is {self.max_inputs}, {self.num_input_files} found.")


### PR DESCRIPTION
Adds:
- Capability of tools to have an unlimited number of input files, by specifying `max_inputs=None` in the class `__init__()` function. 

(Note: `max_inputs` is set to `None` by default if left unspecified during `__init__()`, but all of our current tools specify `max_inputs` explicitly.)

Removes:
- The arbitrary cap of 10 input files for `megahit`.
- The arbitrary cap of 10 input files for `shi7`. 

(Both tools can now have an unlimited number of inputs.)