### PR TITLE
Refactor downloads, add download interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.7.48"
+version = "0.7.49"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/tests/test_chaining.py
+++ b/tests/test_chaining.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from tests.util import s3, hash
+from tests.util import hash
 import toolchest_client as toolchest
 
 toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -17,7 +17,7 @@ def test_kraken2_output_manual_download():
     Tests Kraken 2 against the standard (v1) database, with
     output manually downloaded after job completion
     """
-    test_dir = "test_kraken2_standard"
+    test_dir = "test_kraken2_output_manual_download"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_s3_uri = "s3://toolchest-integration-tests-public/synthetic_bacteroides_reads.fasta"
     output_dir_path = f"./{test_dir}/"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -22,8 +22,10 @@ def test_kraken2_output_manual_download():
     input_file_s3_uri = "s3://toolchest-integration-tests-public/synthetic_bacteroides_reads.fasta"
     manual_output_dir_path = f"./{test_dir}/manual/"
     manual_output_file_path = f"{manual_output_dir_path}kraken2_output.txt"
-    toolchest_output_dir_path = f"./{test_dir}/toolchest/"
-    toolchest_output_file_path = f"{toolchest_output_dir_path}kraken2_output.txt"
+    toolchest_s3_dir_path = f"./{test_dir}/toolchest/s3/"
+    toolchest_s3_file_path = f"{toolchest_s3_dir_path}kraken2_output.txt"
+    toolchest_pipeline_dir_path = f"./{test_dir}/toolchest/id/"
+    toolchest_pipeline_file_path = f"{toolchest_s3_dir_path}kraken2_output.txt"
 
     # Run job without downloading
     output = toolchest.kraken2(
@@ -40,15 +42,27 @@ def test_kraken2_output_manual_download():
     else:
         path_from_manual_download = [path_from_manual_download]
     assert os.path.normpath(manual_output_file_path) in path_from_manual_download
-
     assert hash.unordered(manual_output_file_path) == KRAKEN2_SINGLE_END_HASH
 
-    # Test again with toolchest.download()
-    path_from_toolchest_download = toolchest.download(toolchest_output_dir_path, s3_uri=output.s3_uri)
+    # Test again with toolchest.download(), using S3 URI
+    path_from_toolchest_download = toolchest.download(toolchest_s3_dir_path, s3_uri=output.s3_uri)
     if isinstance(path_from_toolchest_download, list):
         path_from_toolchest_download = [os.path.normpath(path) for path in path_from_toolchest_download]
     else:
         path_from_toolchest_download = [path_from_toolchest_download]
-    assert os.path.normpath(toolchest_output_file_path) in path_from_toolchest_download
+    assert os.path.normpath(toolchest_s3_file_path) in path_from_toolchest_download
+    assert hash.unordered(toolchest_s3_file_path) == KRAKEN2_SINGLE_END_HASH
 
-    assert hash.unordered(toolchest_output_file_path) == KRAKEN2_SINGLE_END_HASH
+    # Test again with toolchest.download(), using pipeline segment instance ID
+    PIPELINE_INDEX_IN_S3_URI = 3
+    pipeline_segment_instance_id = output.s3_uri.split("/")[PIPELINE_INDEX_IN_S3_URI]
+    path_from_toolchest_download = toolchest.download(
+        toolchest_pipeline_dir_path,
+        pipeline_segment_instance_id=pipeline_segment_instance_id,
+    )
+    if isinstance(path_from_toolchest_download, list):
+        path_from_toolchest_download = [os.path.normpath(path) for path in path_from_toolchest_download]
+    else:
+        path_from_toolchest_download = [path_from_toolchest_download]
+    assert os.path.normpath(toolchest_pipeline_file_path) in path_from_toolchest_download
+    assert hash.unordered(toolchest_pipeline_file_path) == KRAKEN2_SINGLE_END_HASH

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -20,8 +20,10 @@ def test_kraken2_output_manual_download():
     test_dir = "test_kraken2_output_manual_download"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_s3_uri = "s3://toolchest-integration-tests-public/synthetic_bacteroides_reads.fasta"
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}kraken2_output.txt"
+    manual_output_dir_path = f"./{test_dir}/manual/"
+    manual_output_file_path = f"{manual_output_dir_path}kraken2_output.txt"
+    toolchest_output_dir_path = f"./{test_dir}/toolchest/"
+    toolchest_output_file_path = f"{toolchest_output_dir_path}kraken2_output.txt"
 
     # Run job without downloading
     output = toolchest.kraken2(
@@ -29,7 +31,7 @@ def test_kraken2_output_manual_download():
     )
 
     # Manually invoke download from output
-    path_from_manual_download = output.download(output_dir_path)
+    path_from_manual_download = output.download(manual_output_dir_path)
 
     # If multiple files are returned, path_from_manual download will be a list,
     # so we simply check if kraken2_output.txt is contained in it
@@ -37,19 +39,16 @@ def test_kraken2_output_manual_download():
         path_from_manual_download = [os.path.normpath(path) for path in path_from_manual_download]
     else:
         path_from_manual_download = [path_from_manual_download]
-    assert os.path.normpath(output_file_path) in path_from_manual_download
+    assert os.path.normpath(manual_output_file_path) in path_from_manual_download
 
-    assert hash.unordered(output_file_path) == KRAKEN2_SINGLE_END_HASH
+    assert hash.unordered(manual_output_file_path) == KRAKEN2_SINGLE_END_HASH
 
-    # Clear directory and test again with toolchest.download()
-    for output_file in os.listdir(output_dir_path):
-        os.remove(os.path.join(output_dir_path, output_file))
-
-    path_from_toolchest_download = toolchest.download(output_dir_path, s3_uri=output.s3_uri)
+    # Test again with toolchest.download()
+    path_from_toolchest_download = toolchest.download(toolchest_output_dir_path, s3_uri=output.s3_uri)
     if isinstance(path_from_toolchest_download, list):
         path_from_toolchest_download = [os.path.normpath(path) for path in path_from_toolchest_download]
     else:
         path_from_toolchest_download = [path_from_toolchest_download]
-    assert os.path.normpath(output_file_path) in path_from_toolchest_download
+    assert os.path.normpath(toolchest_output_file_path) in path_from_toolchest_download
 
-    assert hash.unordered(output_file_path) == KRAKEN2_SINGLE_END_HASH
+    assert hash.unordered(toolchest_output_file_path) == KRAKEN2_SINGLE_END_HASH

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,55 @@
+import os
+import pytest
+
+from tests.util import hash
+import toolchest_client as toolchest
+
+toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
+if toolchest_api_key:
+    toolchest.set_key(toolchest_api_key)
+
+KRAKEN2_SINGLE_END_HASH = 886254946
+
+
+@pytest.mark.integration
+def test_kraken2_output_manual_download():
+    """
+    Tests Kraken 2 against the standard (v1) database, with
+    output manually downloaded after job completion
+    """
+    test_dir = "test_kraken2_standard"
+    os.makedirs(f"./{test_dir}", exist_ok=True)
+    input_file_s3_uri = "s3://toolchest-integration-tests-public/synthetic_bacteroides_reads.fasta"
+    output_dir_path = f"./{test_dir}/"
+    output_file_path = f"{output_dir_path}kraken2_output.txt"
+
+    # Run job without downloading
+    output = toolchest.kraken2(
+        inputs=input_file_s3_uri,
+    )
+
+    # Manually invoke download from output
+    path_from_manual_download = output.download(output_dir_path)
+
+    # If multiple files are returned, path_from_manual download will be a list,
+    # so we simply check if kraken2_output.txt is contained in it
+    if isinstance(path_from_manual_download, list):
+        path_from_manual_download = [os.path.normpath(path) for path in path_from_manual_download]
+    else:
+        path_from_manual_download = [path_from_manual_download]
+    assert os.path.normpath(output_file_path) in path_from_manual_download
+
+    assert hash.unordered(output_file_path) == KRAKEN2_SINGLE_END_HASH
+
+    # Clear directory and test again with toolchest.download()
+    for output_file in os.listdir(output_dir_path):
+        os.remove(os.path.join(output_dir_path, output_file))
+
+    path_from_toolchest_download = toolchest.download(output_dir_path, s3_uri=output.s3_uri)
+    if isinstance(path_from_toolchest_download, list):
+        path_from_toolchest_download = [os.path.normpath(path) for path in path_from_toolchest_download]
+    else:
+        path_from_toolchest_download = [path_from_toolchest_download]
+    assert os.path.normpath(output_file_path) in path_from_toolchest_download
+
+    assert hash.unordered(output_file_path) == KRAKEN2_SINGLE_END_HASH

--- a/tests/test_kraken2.py
+++ b/tests/test_kraken2.py
@@ -8,6 +8,8 @@ toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
 if toolchest_api_key:
     toolchest.set_key(toolchest_api_key)
 
+KRAKEN2_SINGLE_END_HASH = 886254946
+
 
 @pytest.mark.integration
 def test_kraken2_standard():
@@ -30,7 +32,7 @@ def test_kraken2_standard():
         output_path=output_dir_path,
     )
 
-    assert hash.unordered(output_file_path) == 886254946
+    assert hash.unordered(output_file_path) == KRAKEN2_SINGLE_END_HASH
 
 
 @pytest.mark.integration
@@ -84,4 +86,4 @@ def test_kraken2_s3():
         output_path=output_dir_path,
     )
 
-    assert hash.unordered(output_file_path) == 886254946
+    assert hash.unordered(output_file_path) == KRAKEN2_SINGLE_END_HASH

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -19,6 +19,7 @@ load_dotenv(find_dotenv(".env"))
 builtins.print = functools.partial(print, flush=True)
 
 from toolchest_client.api.auth import get_key, set_key
+from toolchest_client.api.download import download
 from toolchest_client.api.exceptions import ToolchestException, DataLimitError, ToolchestJobError, ToolchestDownloadError
 from toolchest_client.api.query import Query
 from .tools.api import bowtie2, cellranger_mkfastq, kraken2, megahit, shi7, shogun_align, shogun_filter, STAR, test, unicycler

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -19,6 +19,6 @@ load_dotenv(find_dotenv(".env"))
 builtins.print = functools.partial(print, flush=True)
 
 from toolchest_client.api.auth import get_key, set_key
-from toolchest_client.api.exceptions import ToolchestException, DataLimitError, ToolchestJobError
+from toolchest_client.api.exceptions import ToolchestException, DataLimitError, ToolchestJobError, ToolchestDownloadError
 from toolchest_client.api.query import Query
 from .tools.api import bowtie2, cellranger_mkfastq, kraken2, megahit, shi7, shogun_align, shogun_filter, STAR, test, unicycler

--- a/toolchest_client/api/auth.py
+++ b/toolchest_client/api/auth.py
@@ -13,6 +13,7 @@ import requests
 from requests.exceptions import HTTPError
 
 from toolchest_client.api.exceptions import ToolchestKeyError
+from toolchest_client.api.urls import BASE_URL
 
 
 def get_key():
@@ -51,12 +52,9 @@ def set_key(key):
 def validate_key():
     """Validates Toolchest API key, retrieved from get_key()."""
 
-    BASE_URL = os.environ.get("BASE_URL", "https://api.toolche.st")
-    HEADERS = {"Authorization": f"Key {get_key()}"}
-
     validation_response = requests.get(
         BASE_URL,
-        headers=HEADERS,
+        headers=get_headers(),
     )
     try:
         validation_response.raise_for_status()
@@ -64,3 +62,8 @@ def validate_key():
         error_message = "Invalid Toolchest auth key. Please check the key value or contact Toolchest."
         print(error_message, file=sys.stderr)
         raise ToolchestKeyError(error_message) from None
+
+
+def get_headers():
+    """Returns headers for Toolchest API calls."""
+    return {"Authorization": f"Key {get_key()}"}

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -17,11 +17,26 @@ from requests.exceptions import HTTPError
 from toolchest_client.api.auth import get_headers
 from toolchest_client.api.exceptions import ToolchestDownloadError
 from toolchest_client.api.urls import PIPELINE_URL
-from toolchest_client.files import get_file_type, unpack_files
+from toolchest_client.files import get_file_type, get_params_from_s3_uri, unpack_files
 
 
-def download(output_path, output_file_keys, output_type=None):
-    """Downloads output to ``output_path``."""
+def download(output_path, s3_uri=None, output_file_keys=None, output_type=None):
+    """Downloads output to ``output_path``.
+
+    One of output_file_keys or s3_uri must be provided. If output_file_keys is
+    omitted, this function will attempt to extract access keys from s3_uri via
+    get_download_details().
+    """
+
+    if output_file_keys is None:
+        if s3_uri:
+            # Note: this assumes the pipeline segment instance ID is embedded in the egress S3 URI.
+            s3_uri_params = get_params_from_s3_uri(s3_uri)
+            pipeline_segment_instance_id = s3_uri_params["key_initial"]
+            output_s3_uri, output_file_keys = get_download_details(pipeline_segment_instance_id)
+        else:
+            error_message = "S3 URI of output not provided."
+            raise ToolchestDownloadError(error_message) from None
 
     try:
         s3_client = boto3.client(
@@ -40,21 +55,22 @@ def download(output_path, output_file_keys, output_type=None):
         error_message = f"{err} \n\nOutput download failed."
         raise ToolchestDownloadError(error_message) from None
 
-    unpacked_output_files = _unpack_output(output_path, output_type=output_type)
-    return unpacked_output_files
+    unpacked_output_paths = _unpack_output(output_path, output_type=output_type)
+    return unpacked_output_paths
 
 
-def get_download_details(pipeline_segment_id):
+def get_download_details(pipeline_segment_instance_id):
     """Gets S3 URI and access keys for downloading output of query task(s)."""
 
     response = requests.get(
-        "/".join([PIPELINE_URL, pipeline_segment_id, "downloads"]),
+        "/".join([PIPELINE_URL, pipeline_segment_instance_id, "downloads"]),
         headers=get_headers(),
     )
     try:
         response.raise_for_status()
     except HTTPError:
-        error_message = "An error occurred in getting the output S3 URI and download access keys."
+        error_message = ("An error occurred in getting the output S3 URI and download access keys. "
+                         f"Pipeline segment instance ID: {pipeline_segment_instance_id}")
         raise ToolchestDownloadError(error_message) from None
 
     response_json = response.json()[0]  # assumes only one output file

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -1,0 +1,82 @@
+"""
+toolchest_client.api.download
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module provides an interface to download files contained on
+the Toolchest server, given access to an API key.
+
+Note: This module is used in downloading from the Output and
+Query classes.
+"""
+
+import boto3
+from botocore.exceptions import ClientError
+import requests
+from requests.exceptions import HTTPError
+
+from toolchest_client.api.auth import get_headers
+from toolchest_client.api.exceptions import ToolchestDownloadError
+from toolchest_client.api.urls import PIPELINE_URL
+from toolchest_client.files import unpack_files
+
+
+def download(output_path):
+    """Downloads output to ``output_path``."""
+
+    output_file_keys = _get_download_details()
+
+    try:
+        s3_client = boto3.client(
+            's3',
+            aws_access_key_id=output_file_keys["access_key_id"],
+            aws_secret_access_key=output_file_keys["secret_access_key"],
+            aws_session_token=output_file_keys["session_token"],
+        )
+        s3_client.download_file(
+            output_file_keys["bucket"],
+            output_file_keys["object_name"],
+            output_path,
+        )
+
+    except ClientError as e:
+        # TODO: output more detailed error message if write error encountered
+        error_message = f"{e} \n\nOutput download failed."
+        raise ToolchestDownloadError(error_message) from None
+
+
+def _get_download_details(pipeline_segment_id):
+    """Gets S3 URI and presigned URL for downloading output of query task(s)."""
+
+    response = requests.get(
+        "/".join([PIPELINE_URL, pipeline_segment_id, "downloads"]),
+        headers=get_headers(),
+    )
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        error_message = "Download URL retrieval failed."
+        raise ToolchestDownloadError(error_message) from None
+
+    response_json = response.json()[0]  # assumes only one output file
+    self.output_s3_uri = response_json.get("s3_uri")
+    return {
+        "access_key_id": response_json.get('access_key_id'),
+        "secret_access_key": response_json.get('secret_access_key'),
+        "session_token": response_json.get('session_token'),
+        "bucket": response_json.get('bucket'),
+        "object_name": response_json.get('object_name'),
+    }
+
+
+def _unpack_output(compressed_output_path, output_type):
+    """After downloading, unpack files if needed"""
+    try:
+        unpacked_output_paths = unpack_files(
+            file_path_to_unpack=compressed_output_path,
+            output_type=output_type,
+        )
+    except Exception as err:
+        error_message = f"Failed to unpack file with type: {output_type}."
+        raise ToolchestDownloadError(error_message) from err
+    return unpacked_output_paths
+

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -9,6 +9,8 @@ Note: This module is used in downloading from the Output and
 Query classes.
 """
 
+import os
+
 import boto3
 from botocore.exceptions import ClientError
 import requests
@@ -37,6 +39,12 @@ def download(output_path, s3_uri=None, output_file_keys=None, output_type=None):
         else:
             error_message = "S3 URI of output not provided."
             raise ToolchestDownloadError(error_message) from None
+    print(output_file_keys)
+
+    # If output_path is a directory, extract the filename from the target download.
+    if os.path.isdir(output_path):
+        file_name = output_file_keys["file_name"]
+        output_path = "/".join([output_path, file_name])
 
     try:
         s3_client = boto3.client(
@@ -81,6 +89,7 @@ def get_download_details(pipeline_segment_instance_id):
         "session_token": response_json.get('session_token'),
         "bucket": response_json.get('bucket'),
         "object_name": response_json.get('object_name'),
+        "file_name": response_json.get('file_name'),
     }
     return output_s3_uri, output_file_keys
 

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -22,19 +22,35 @@ from toolchest_client.api.urls import PIPELINE_URL
 from toolchest_client.files import get_file_type, get_params_from_s3_uri, unpack_files
 
 
-def download(output_path, s3_uri=None, output_file_keys=None, output_type=None):
+def download(output_path, s3_uri=None, pipeline_segment_instance_id=None,
+             output_file_keys=None, output_type=None, ):
     """Downloads output to ``output_path``.
 
-    One of output_file_keys or s3_uri must be provided. If output_file_keys is
-    omitted, this function will attempt to extract access keys from s3_uri via
-    get_download_details().
+    One of `s3_uri`, `pipeline_segment_instance_id`, or `output_file_keys` must
+    be provided. If `output_file_keys` is omitted, this function will attempt to
+    extract access keys from `s3_uri` or `pipeline_segment_instance_id` via
+    `get_download_details()`.
+
+    :param output_path: Output path to which the file(s) will be downloaded.
+        This should be a directory that already exists, but direct filenames
+        are also supported.
+    :param s3_uri: URI of file contained in S3. This can be passed from
+        the parameter `output.s3_uri` from the `output` returned by a previous
+        job.
+    :param pipeline_segment_instance_id: Pipeline segment instance ID of the job
+        producing the output you would like to download.
+    :param output_file_keys: Access keys obtained from `get_download_details()`.
+        Used internally.
+    :param output_type: Output type of the produced output file. Used internally.
     """
 
     if output_file_keys is None:
         if s3_uri:
             # Note: this assumes the pipeline segment instance ID is embedded in the egress S3 URI.
+            # This supersedes pipeline_segment_instance_id, if it is provided.
             s3_uri_params = get_params_from_s3_uri(s3_uri)
             pipeline_segment_instance_id = s3_uri_params["key_initial"]
+        if pipeline_segment_instance_id:
             output_s3_uri, output_file_keys = get_download_details(pipeline_segment_instance_id)
         else:
             error_message = "S3 URI of output not provided."

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -24,7 +24,7 @@ from toolchest_client.files import get_file_type, get_params_from_s3_uri, unpack
 
 def download(output_path, s3_uri=None, pipeline_segment_instance_id=None,
              output_file_keys=None, output_type=None, ):
-    """Downloads output to ``output_path``.
+    """Downloads output to `output_path`.
 
     One of `s3_uri`, `pipeline_segment_instance_id`, or `output_file_keys` must
     be provided. If `output_file_keys` is omitted, this function will attempt to
@@ -55,7 +55,6 @@ def download(output_path, s3_uri=None, pipeline_segment_instance_id=None,
         else:
             error_message = "S3 URI of output not provided."
             raise ToolchestDownloadError(error_message) from None
-    print(output_file_keys)
 
     # If output_path is a directory, extract the filename from the target download.
     if os.path.isdir(output_path):

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -17,13 +17,11 @@ from requests.exceptions import HTTPError
 from toolchest_client.api.auth import get_headers
 from toolchest_client.api.exceptions import ToolchestDownloadError
 from toolchest_client.api.urls import PIPELINE_URL
-from toolchest_client.files import unpack_files
+from toolchest_client.files import get_file_type, unpack_files
 
 
-def download(output_path):
+def download(output_path, output_file_keys, output_type=None):
     """Downloads output to ``output_path``."""
-
-    output_file_keys = _get_download_details()
 
     try:
         s3_client = boto3.client(
@@ -37,15 +35,17 @@ def download(output_path):
             output_file_keys["object_name"],
             output_path,
         )
-
-    except ClientError as e:
+    except ClientError as err:
         # TODO: output more detailed error message if write error encountered
-        error_message = f"{e} \n\nOutput download failed."
+        error_message = f"{err} \n\nOutput download failed."
         raise ToolchestDownloadError(error_message) from None
 
+    unpacked_output_files = _unpack_output(output_path, output_type=output_type)
+    return unpacked_output_files
 
-def _get_download_details(pipeline_segment_id):
-    """Gets S3 URI and presigned URL for downloading output of query task(s)."""
+
+def get_download_details(pipeline_segment_id):
+    """Gets S3 URI and access keys for downloading output of query task(s)."""
 
     response = requests.get(
         "/".join([PIPELINE_URL, pipeline_segment_id, "downloads"]),
@@ -54,22 +54,26 @@ def _get_download_details(pipeline_segment_id):
     try:
         response.raise_for_status()
     except HTTPError:
-        error_message = "Download URL retrieval failed."
+        error_message = "An error occurred in getting the output S3 URI and download access keys."
         raise ToolchestDownloadError(error_message) from None
 
     response_json = response.json()[0]  # assumes only one output file
-    self.output_s3_uri = response_json.get("s3_uri")
-    return {
+    output_s3_uri = response_json.get("s3_uri")
+    output_file_keys = {
         "access_key_id": response_json.get('access_key_id'),
         "secret_access_key": response_json.get('secret_access_key'),
         "session_token": response_json.get('session_token'),
         "bucket": response_json.get('bucket'),
         "object_name": response_json.get('object_name'),
     }
+    return output_s3_uri, output_file_keys
 
 
-def _unpack_output(compressed_output_path, output_type):
+def _unpack_output(compressed_output_path, output_type=None):
     """After downloading, unpack files if needed"""
+    if output_type is None:
+        output_type = get_file_type(compressed_output_path)
+
     try:
         unpacked_output_paths = unpack_files(
             file_path_to_unpack=compressed_output_path,

--- a/toolchest_client/api/exceptions.py
+++ b/toolchest_client/api/exceptions.py
@@ -15,8 +15,14 @@ class ToolchestException(OSError):
 class ToolchestKeyError(ToolchestException):
     """Invalid Toolchest auth key."""
 
+
 class ToolchestS3AccessError(ToolchestException):
     """S3 input cannot be accessed by Toolchest."""
+
+
+class ToolchestDownloadError(ToolchestException):
+    """An error occurred when downloading files from Toolchest."""
+
 
 class DataLimitError(ToolchestException):
     """Data limit for Toolchest exceeded."""

--- a/toolchest_client/api/output.py
+++ b/toolchest_client/api/output.py
@@ -10,6 +10,7 @@ Note: The Output object does NOT represent the contents of any of the
 tool output files themselves.
 """
 
+from toolchest_client.api.download import download
 
 class Output:
     """A Toolchest query output.
@@ -29,6 +30,9 @@ class Output:
     def __str__(self):
         return str(self.__dict__)
 
-    def download(self):
-        pass
-        # TODO: add call to download once finished
+    def download(self, output_dir):
+        self.output_path = download(
+            output_dir,
+            s3_uri=self.s3_uri,
+        )
+        return self.output_path

--- a/toolchest_client/api/output.py
+++ b/toolchest_client/api/output.py
@@ -29,3 +29,7 @@ class Output:
 
     def __str__(self):
         return str(self.__dict__)
+
+    def download(self):
+        pass
+        # TODO: add call to download once finished

--- a/toolchest_client/api/output.py
+++ b/toolchest_client/api/output.py
@@ -6,8 +6,8 @@ This module provides an Output object returned by any completed queries
 made by Toolchest tools. The output object contains information about
 where the output file can be located.
 
-Note: The Output object does NOT represent any of the tool outputs
-themselves.
+Note: The Output object does NOT represent the contents of any of the
+tool output files themselves.
 """
 
 

--- a/toolchest_client/api/output.py
+++ b/toolchest_client/api/output.py
@@ -19,9 +19,8 @@ class Output:
 
     """
 
-    def __init__(self, s3_uri=None, presigned_s3_url=None, output_path=None):
+    def __init__(self, s3_uri=None, output_path=None):
         self.s3_uri = s3_uri
-        self.presigned_s3_url = presigned_s3_url
         self.output_path = output_path
 
     def __repr__(self):

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -7,7 +7,6 @@ tools. These queries are handled by the Toolchest (server) API.
 """
 
 import ntpath
-import os
 import sys
 import threading
 import time
@@ -22,7 +21,7 @@ from toolchest_client.api.download import download, get_download_details
 from toolchest_client.api.exceptions import ToolchestJobError, ToolchestException, ToolchestDownloadError
 from toolchest_client.api.output import Output
 from toolchest_client.api.urls import PIPELINE_URL
-from toolchest_client.files import unpack_files, OutputType
+from toolchest_client.files import OutputType
 from .status import Status, ThreadStatus
 
 

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -41,7 +41,7 @@ class Query:
 
     def __init__(self, stored_output=None):
         self.HEADERS = dict()
-        self.PIPELINE_SEGMENT_ID = ''
+        self.PIPELINE_SEGMENT_INSTANCE_ID = ''
         self.PIPELINE_SEGMENT_URL = ''
         self.STATUS_URL = ''
         self.mark_as_failed = False
@@ -91,10 +91,10 @@ class Query:
 
         self._update_thread_status(ThreadStatus.INITIALIZED)
 
-        self.PIPELINE_SEGMENT_ID = create_content["id"]
+        self.PIPELINE_SEGMENT_INSTANCE_ID = create_content["id"]
         self.PIPELINE_SEGMENT_URL = "/".join([
             PIPELINE_URL,
-            self.PIPELINE_SEGMENT_ID
+            self.PIPELINE_SEGMENT_INSTANCE_ID
         ])
         self.STATUS_URL = "/".join([
             self.PIPELINE_SEGMENT_URL,
@@ -340,7 +340,7 @@ class Query:
         """
 
         try:
-            self.output_s3_uri, output_file_keys = get_download_details(self.PIPELINE_SEGMENT_ID)
+            self.output_s3_uri, output_file_keys = get_download_details(self.PIPELINE_SEGMENT_INSTANCE_ID)
             if output_path:
                 self._update_thread_status(ThreadStatus.DOWNLOADING)
                 self._update_status(Status.TRANSFERRING_TO_CLIENT)

--- a/toolchest_client/api/urls.py
+++ b/toolchest_client/api/urls.py
@@ -1,0 +1,15 @@
+"""
+toolchest_client.api.urls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module serves as a single source for URLs used in
+Toolchest queries and API calls.
+"""
+
+import os
+
+# Base URLs used by the server API.
+BASE_URL = os.environ.get("BASE_URL", "https://api.toolche.st")
+PIPELINE_ROUTE = "/pipeline-segment-instances"
+PIPELINE_URL = BASE_URL + PIPELINE_ROUTE
+

--- a/toolchest_client/files/__init__.py
+++ b/toolchest_client/files/__init__.py
@@ -2,4 +2,4 @@ from .general import assert_exists, check_file_size, files_in_path, sanity_check
 from .merge import concatenate_files, merge_sam_files
 from .s3 import assert_accessible_s3, get_params_from_s3_uri
 from .split import open_new_output_file, split_file_by_lines, split_paired_files_by_lines
-from .unpack import OutputType, unpack_files
+from .unpack import OutputType, unpack_files, get_file_type

--- a/toolchest_client/files/s3.py
+++ b/toolchest_client/files/s3.py
@@ -52,6 +52,7 @@ def get_params_from_s3_uri(uri):
     arn = "arn:aws:s3:::" + "/".join(uri_split[S3_BUCKET_INDEX:])
     bucket = uri_split[S3_BUCKET_INDEX]
     key_initial = uri_split[S3_KEY_INITIAL_INDEX]
+    key_final = uri_split[-1]
     key = "/".join(uri_split[S3_KEY_INITIAL_INDEX:])
 
     params = {
@@ -59,6 +60,7 @@ def get_params_from_s3_uri(uri):
         "bucket": bucket,
         "key": key,
         "key_initial": key_initial,
+        "key_final": key_final,
     }
 
     return params

--- a/toolchest_client/files/s3.py
+++ b/toolchest_client/files/s3.py
@@ -44,18 +44,21 @@ def get_params_from_s3_uri(uri):
     :param uri: An S3 URI.
     """
 
-    # Index of S3 bucket name in the URI (when split by slashes).
+    # Index of S3 bucket name and initial key directory in the URI (when split by slashes).
     S3_BUCKET_INDEX = 2
+    S3_KEY_INITIAL_INDEX = S3_BUCKET_INDEX + 1
     uri_split = uri.split(sep="/")
 
     arn = "arn:aws:s3:::" + "/".join(uri_split[S3_BUCKET_INDEX:])
     bucket = uri_split[S3_BUCKET_INDEX]
-    key = "/".join(uri_split[S3_BUCKET_INDEX+1:])
+    key_initial = uri_split[S3_KEY_INITIAL_INDEX]
+    key = "/".join(uri_split[S3_KEY_INITIAL_INDEX:])
 
     params = {
         "arn": arn,
         "bucket": bucket,
         "key": key,
+        "key_initial": key_initial,
     }
 
     return params

--- a/toolchest_client/files/s3.py
+++ b/toolchest_client/files/s3.py
@@ -10,8 +10,9 @@ import sys
 import requests
 from requests.exceptions import HTTPError
 
-from toolchest_client.api.auth import get_key
+from toolchest_client.api.auth import get_headers
 from toolchest_client.api.exceptions import ToolchestS3AccessError
+from toolchest_client.api.urls import BASE_URL
 
 
 def assert_accessible_s3(uri):
@@ -19,15 +20,10 @@ def assert_accessible_s3(uri):
 
     :param uri: An S3 URI.
     """
-    # TODO: move BASE_URL, HEADERS into a new module
-
-    BASE_URL = os.environ.get("BASE_URL", "https://api.toolche.st")
-    HEADERS = {"Authorization": f"Key {get_key()}"}
-
     params = get_params_from_s3_uri(uri)
     response = requests.post(
         f"{BASE_URL}/validate-s3-input/",
-        headers=HEADERS,
+        headers=get_headers(),
         json=params,
     )
     try:

--- a/toolchest_client/files/tests/test_s3.py
+++ b/toolchest_client/files/tests/test_s3.py
@@ -12,6 +12,7 @@ def test_s3_params():
         "bucket": "toolchest-public-examples",
         "key": "dummy-id/example.fastq",
         "key_initial": "dummy-id",
+        "key_final": "example.fastq"
     }
 
     assert params == target_params

--- a/toolchest_client/files/tests/test_s3.py
+++ b/toolchest_client/files/tests/test_s3.py
@@ -5,7 +5,7 @@ from ...api.exceptions import ToolchestS3AccessError
 
 
 def test_s3_params():
-    example_s3_uri = "s3://toolchest-public-examples/example.fastq"
+    example_s3_uri = "s3://toolchest-public-examples/dummy-id/example.fastq"
     params = get_params_from_s3_uri(example_s3_uri)
     target_params = {
         "arn": "arn:aws:s3:::toolchest-public-examples/dummy-id/example.fastq",

--- a/toolchest_client/files/tests/test_s3.py
+++ b/toolchest_client/files/tests/test_s3.py
@@ -8,9 +8,10 @@ def test_s3_params():
     example_s3_uri = "s3://toolchest-public-examples/example.fastq"
     params = get_params_from_s3_uri(example_s3_uri)
     target_params = {
-        "arn": "arn:aws:s3:::toolchest-public-examples/example.fastq",
+        "arn": "arn:aws:s3:::toolchest-public-examples/dummy-id/example.fastq",
         "bucket": "toolchest-public-examples",
-        "key": "example.fastq"
+        "key": "dummy-id/example.fastq",
+        "key_initial": "dummy-id",
     }
 
     assert params == target_params

--- a/toolchest_client/files/unpack.py
+++ b/toolchest_client/files/unpack.py
@@ -45,3 +45,15 @@ def unpack_files(file_path_to_unpack, output_type):
 
     else:
         raise NotImplementedError(f"Output type {output_type} unpacking is not implemented")
+
+
+def get_file_type(file_path):
+    """Gets file type from available types registered in OutputType.
+    Raises an error if the file does not match any registered type.
+
+    TODO: add default handling for plaintext files apart from .txt files
+    """
+    for output_type in OutputType:
+        if file_path.endswith(output_type.value):
+            return output_type
+    raise NotImplementedError(f"Handling of output type for file at {file_path} is not implemented")

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -39,7 +39,8 @@ def bowtie2(inputs, output_path=None, database_name="GRCh38_noalt_as", database_
         database_name=database_name,
         database_version=database_version
     )
-    return instance.run()
+    output = instance.run()
+    return output
 
 
 def cellranger_mkfastq(inputs, samplesheet_name, output_path=None, tool_args=""):
@@ -72,7 +73,8 @@ def cellranger_mkfastq(inputs, samplesheet_name, output_path=None, tool_args="")
         inputs=inputs,
         output_path=output_path,
     )
-    return instance.run()
+    output = instance.run()
+    return output
 
 
 def kraken2(output_path=None, inputs=[], database_name="standard", database_version="1",
@@ -132,7 +134,8 @@ def kraken2(output_path=None, inputs=[], database_name="standard", database_vers
         database_name=database_name,
         database_version=database_version,
     )
-    return instance.run()
+    output = instance.run()
+    return output
 
 
 def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interleaved=None,
@@ -190,7 +193,8 @@ def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interl
         inputs=input_list,
         output_path=output_path,
     )
-    return instance.run()
+    output = instance.run()
+    return output
 
 
 def shi7(inputs, output_path=None, tool_args=""):
@@ -217,7 +221,8 @@ def shi7(inputs, output_path=None, tool_args=""):
         inputs=inputs,
         output_path=output_path,
     )
-    return instance.run()
+    output = instance.run()
+    return output
 
 
 def shogun_align(inputs, output_path=None, database_name="shogun_standard", database_version="1", tool_args=""):
@@ -251,7 +256,8 @@ def shogun_align(inputs, output_path=None, database_name="shogun_standard", data
         database_name=database_name,
         database_version=database_version,
     )
-    return instance.run()
+    output = instance.run()
+    return output
 
 
 def shogun_filter(inputs, output_path=None, database_name="shogun_standard", database_version="1", tool_args=""):
@@ -285,7 +291,8 @@ def shogun_filter(inputs, output_path=None, database_name="shogun_standard", dat
         database_name=database_name,
         database_version=database_version,
     )
-    return instance.run()
+    output = instance.run()
+    return output
 
 
 def STAR(read_one, database_name, output_path=None, database_version="1", read_two=None, tool_args="", parallelize=False):
@@ -331,7 +338,8 @@ def STAR(read_one, database_name, output_path=None, database_version="1", read_t
         database_version=database_version,
         parallelize=parallelize,
     )
-    return instance.run()
+    output = instance.run()
+    return output
 
 
 def test(inputs, output_path=None, tool_args=""):
@@ -357,7 +365,8 @@ def test(inputs, output_path=None, tool_args=""):
         inputs=inputs,
         output_path=output_path,
     )
-    return instance.run()
+    output = instance.run()
+    return output
 
 
 def unicycler(output_path=None, read_one=None, read_two=None, long_reads=None, tool_args=""):
@@ -393,4 +402,5 @@ def unicycler(output_path=None, read_one=None, read_two=None, long_reads=None, t
         inputs=[read_one, read_two, long_reads],
         output_path=output_path,
     )
-    return instance.run()
+    output = instance.run()
+    return output

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -39,7 +39,7 @@ def bowtie2(inputs, output_path=None, database_name="GRCh38_noalt_as", database_
         database_name=database_name,
         database_version=database_version
     )
-    instance.run()
+    return instance.run()
 
 
 def cellranger_mkfastq(inputs, samplesheet_name, output_path=None, tool_args=""):
@@ -72,7 +72,7 @@ def cellranger_mkfastq(inputs, samplesheet_name, output_path=None, tool_args="")
         inputs=inputs,
         output_path=output_path,
     )
-    instance.run()
+    return instance.run()
 
 
 def kraken2(output_path=None, inputs=[], database_name="standard", database_version="1",
@@ -132,7 +132,7 @@ def kraken2(output_path=None, inputs=[], database_name="standard", database_vers
         database_name=database_name,
         database_version=database_version,
     )
-    instance.run()
+    return instance.run()
 
 
 def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interleaved=None,
@@ -190,7 +190,7 @@ def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interl
         inputs=input_list,
         output_path=output_path,
     )
-    instance.run()
+    return instance.run()
 
 
 def shi7(inputs, output_path=None, tool_args=""):
@@ -331,7 +331,7 @@ def STAR(read_one, database_name, output_path=None, database_version="1", read_t
         database_version=database_version,
         parallelize=parallelize,
     )
-    instance.run()
+    return instance.run()
 
 
 def test(inputs, output_path=None, tool_args=""):
@@ -357,7 +357,7 @@ def test(inputs, output_path=None, tool_args=""):
         inputs=inputs,
         output_path=output_path,
     )
-    instance.run()
+    return instance.run()
 
 
 def unicycler(output_path=None, read_one=None, read_two=None, long_reads=None, tool_args=""):
@@ -393,4 +393,4 @@ def unicycler(output_path=None, read_one=None, read_two=None, long_reads=None, t
         inputs=[read_one, read_two, long_reads],
         output_path=output_path,
     )
-    instance.run()
+    return instance.run()


### PR DESCRIPTION
Adds:
* `toolchest.download(output_path, s3_uri="s3://your-s3-uri")` and `output.download(output_dir)`, user-invoked functions which can download an output after its job has completed.
* `ToolchestDownloadException`, a new exception thrown whenever an error is encountered in downloading or unpacking.
* Integration tests for manual downloads.

Modifies:
* Code for downloading has now been moved from `Query` to `api/downloads.py`, which serves as a single source for all download functionality.
* Downloads during `Query.run_query()` now call the functions in `api/downloads.py`.
* URLs used for the API have been moved to `api/urls.py`, which serves as a single source for all API URLs.
* All `toolchest.tool()` calls now correctly return an `Output`.

Removes:
* `presigned_s3_url` parameter for `Output`