### PR TITLE
Megahit integration tests + integration test bugfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.7.49"
+version = "0.7.50"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/tests/test_megahit.py
+++ b/tests/test_megahit.py
@@ -8,21 +8,25 @@ toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
 if toolchest_api_key:
     toolchest.set_key(toolchest_api_key)
 
+EXPECTED_MIN_OUTPUT_SIZE = 1000
+
+
 @pytest.mark.integration
-def test_megahit_one_pair():
+def test_megahit_many_types():
     """
-    Tests Megahit with a single pair of paired-end inputs.
+    Tests Megahit with two interleaved inputs, one pair of paired-end inputs,
+    and two single-end inputs.
 
     Note: Multithreaded megahit is not deterministic, so
     we check the size of the file instead.
     See https://github.com/voutcn/megahit/issues/48.
     """
-    test_dir = "test_megahit_one_pair"
+    test_dir = "test_megahit_many_types"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}/"
-    # output_file_path = f"{output_dir_path}kraken2_output.txt"
+    output_file_path = f"{output_dir_path}final.contigs.fa"
 
-    output = toolchest.megahit(
+    toolchest.megahit(
         interleaved=[
             "s3://toolchest-integration-tests-public/megahit/r1.il.fa.gz",
             "s3://toolchest-integration-tests-public/megahit/r2.il.fa.bz2",
@@ -36,3 +40,35 @@ def test_megahit_one_pair():
         tool_args="--presets meta-large",
         output_path=output_dir_path,
     )
+
+    assert os.path.getsize(output_file_path) >= EXPECTED_MIN_OUTPUT_SIZE
+
+
+@pytest.mark.integration
+def test_megahit_multiple_pairs():
+    """
+    Tests Megahit with two pairs of paired-end inputs.
+
+    Note: Multithreaded megahit is not deterministic, so
+    we check the size of the file instead.
+    See https://github.com/voutcn/megahit/issues/48.
+    """
+    test_dir = "test_megahit_two_pairs"
+    os.makedirs(f"./{test_dir}", exist_ok=True)
+    output_dir_path = f"./{test_dir}/"
+    output_file_path = f"{output_dir_path}final.contigs.fa"
+
+    toolchest.megahit(
+        read_one=[
+            "s3://toolchest-integration-tests-public/megahit/r3_1.fa",
+            "s3://toolchest-integration-tests-public/r1.fastq.gz",
+        ],
+        read_two=[
+            "s3://toolchest-integration-tests-public/megahit/r3_2.fa",
+            "s3://toolchest-integration-tests-public/r2.fastq.gz",
+        ],
+        tool_args="--presets meta-large",
+        output_path=output_dir_path,
+    )
+
+    assert os.path.getsize(output_file_path) >= EXPECTED_MIN_OUTPUT_SIZE

--- a/tests/test_megahit.py
+++ b/tests/test_megahit.py
@@ -23,8 +23,16 @@ def test_megahit_one_pair():
     # output_file_path = f"{output_dir_path}kraken2_output.txt"
 
     output = toolchest.megahit(
-        read_one="s3://toolchest-integration-tests-public/sample_r1.fastq.gz",
-        read_two="s3://toolchest-integration-tests-public/sample_r2.fastq.gz",
+        interleaved=[
+            "s3://toolchest-integration-tests-public/megahit/r1.il.fa.gz",
+            "s3://toolchest-integration-tests-public/megahit/r2.il.fa.bz2",
+        ],
+        read_one="s3://toolchest-integration-tests-public/megahit/r3_1.fa",
+        read_two="s3://toolchest-integration-tests-public/megahit/r3_2.fa",
+        single_end=[
+            "s3://toolchest-integration-tests-public/megahit/r4.fa",
+            "s3://toolchest-integration-tests-public/megahit/loop.fa",
+        ],
         tool_args="--presets meta-large",
-        output_path="C:/Users/Bryce/Documents/Startup/output-test/megahit",
+        output_path=output_dir_path,
     )

--- a/tests/test_megahit.py
+++ b/tests/test_megahit.py
@@ -8,7 +8,8 @@ toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
 if toolchest_api_key:
     toolchest.set_key(toolchest_api_key)
 
-EXPECTED_MIN_OUTPUT_SIZE = 1000
+EXPECTED_MIN_OUTPUT_SIZE_MANY_TYPES = 1000
+EXPECTED_MIN_OUTPUT_SIZE_TWO_PAIRS = 3 * 1024 * 1024
 
 
 @pytest.mark.integration
@@ -41,7 +42,7 @@ def test_megahit_many_types():
         output_path=output_dir_path,
     )
 
-    assert os.path.getsize(output_file_path) >= EXPECTED_MIN_OUTPUT_SIZE
+    assert os.path.getsize(output_file_path) >= EXPECTED_MIN_OUTPUT_SIZE_MANY_TYPES
 
 
 @pytest.mark.integration
@@ -71,4 +72,4 @@ def test_megahit_multiple_pairs():
         output_path=output_dir_path,
     )
 
-    assert os.path.getsize(output_file_path) >= EXPECTED_MIN_OUTPUT_SIZE
+    assert os.path.getsize(output_file_path) >= EXPECTED_MIN_OUTPUT_SIZE_TWO_PAIRS

--- a/tests/test_megahit.py
+++ b/tests/test_megahit.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+
+from tests.util import hash
+import toolchest_client as toolchest
+
+toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
+if toolchest_api_key:
+    toolchest.set_key(toolchest_api_key)
+
+@pytest.mark.integration
+def test_megahit_one_pair():
+    """
+    Tests Megahit with a single pair of paired-end inputs.
+
+    Note: Multithreaded megahit is not deterministic, so
+    we check the size of the file instead.
+    See https://github.com/voutcn/megahit/issues/48.
+    """
+    test_dir = "test_megahit_one_pair"
+    os.makedirs(f"./{test_dir}", exist_ok=True)
+    output_dir_path = f"./{test_dir}/"
+    # output_file_path = f"{output_dir_path}kraken2_output.txt"
+
+    output = toolchest.megahit(
+        read_one="s3://toolchest-integration-tests-public/sample_r1.fastq.gz",
+        read_two="s3://toolchest-integration-tests-public/sample_r2.fastq.gz",
+        tool_args="--presets meta-large",
+        output_path="C:/Users/Bryce/Documents/Startup/output-test/megahit",
+    )

--- a/tests/test_megahit.py
+++ b/tests/test_megahit.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 
-from tests.util import hash
 import toolchest_client as toolchest
 
 toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")

--- a/toolchest_client/api/output.py
+++ b/toolchest_client/api/output.py
@@ -32,7 +32,7 @@ class Output:
 
     def download(self, output_dir):
         self.output_path = download(
-            output_dir,
+            output_path=output_dir,
             s3_uri=self.s3_uri,
         )
         return self.output_path

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -344,8 +344,8 @@ class Query:
                 self._update_thread_status(ThreadStatus.DOWNLOADING)
                 self._update_status(Status.TRANSFERRING_TO_CLIENT)
                 self.unpacked_output_paths = download(
-                    output_path,
-                    output_file_keys,
+                    output_path=output_path,
+                    output_file_keys=output_file_keys,
                     output_type=output_type,
                 )
                 self._update_status(Status.TRANSFERRED_TO_CLIENT)

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -184,7 +184,10 @@ def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interl
                 }
         elif isinstance(param, str):
             input_list.append(param)
-            input_prefix_mapping[param] = tag
+            input_prefix_mapping[param] = {
+                "prefix": tag,
+                "order": 0,
+            }
 
     instance = Megahit(
         tool_args=tool_args,


### PR DESCRIPTION
Adds:
- Two integration tests for `megahit`:
  - One uses two interleaved inputs, one pair of paired-end inputs, and two single-end inputs. This matches the integration test used in the actual `megahit` package.
  - The other uses two different-sized pairs of paired-end inputs, to test that the API properly processes pairs.

Both integration tests run in 2-4 minutes.

Modifies:
- Bugfix for failing integration tests not using the manual download.
- Bugfix for `megahit` inputs that are given as strings instead of lists of strings.