### PR TITLE
fix: remove pysam and STAR parallelization for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ boto3 = "^1.18.29"
 python = "^3.6"
 requests = "^2.25.1"
 python-dotenv = "^0.18.0"
-pysam = { version = "^0.16.0", markers = "sys_platform == 'linux' or sys_platform == 'darwin'" }
+#pysam = { version = "^0.16.0", markers = "sys_platform == 'linux' or sys_platform == 'darwin'" }
 importlib-metadata = { version = "~=1.0", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -36,6 +36,7 @@ def test_star_grch38():
 
 
 @pytest.mark.integration
+@pytest.mark.skip(reason="Hotfix")
 def test_star_grch38_parallel():
     """
     Tests STAR against the grch38 database, using parallel mode

--- a/toolchest_client/tools/star.py
+++ b/toolchest_client/tools/star.py
@@ -30,7 +30,7 @@ class STARInstance(Tool):
             max_inputs=2,
             database_name=database_name,
             database_version=database_version,
-            parallel_enabled=True if parallelize else False,
+            parallel_enabled=False, # True if parallelize else False
             max_input_bytes_per_file=128 * 1024 * 1024 * 1024,
             max_input_bytes_per_file_parallel=4.5 * 1024 * 1024 * 1024,
             output_type=OutputType.SAM_FILE if parallelize else OutputType.GZ_TAR,


### PR DESCRIPTION
Comments out pysam requirement temporarily and also forces STAR to not be parallelized since that depends on pysam.