### PR TITLE
fix: get integration test files from private S3 bucket

### DIFF
--- a/tests/test_chaining.py
+++ b/tests/test_chaining.py
@@ -33,7 +33,7 @@ def test_shi7_shogun_chaining():
 
     output_shi7 = toolchest.shi7(
         tool_args="-SE",
-        inputs="s3://toolchest-integration-tests-public/sample_r1.fastq.gz",
+        inputs="s3://toolchest-integration-tests/sample_r1.fastq.gz",
     )
 
     # Note: since output_path was omitted from the shi7 function call,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -18,7 +18,7 @@ def test_kraken2_output_manual_download():
     output manually downloaded after job completion
     """
     test_dir = "test_kraken2_output_manual_download"
-    input_file_s3_uri = "s3://toolchest-integration-tests-public/synthetic_bacteroides_reads.fasta"
+    input_file_s3_uri = "s3://toolchest-integration-tests/synthetic_bacteroides_reads.fasta"
     manual_output_dir_path = f"./{test_dir}/manual/"
     manual_output_file_path = f"{manual_output_dir_path}kraken2_output.txt"
     toolchest_s3_dir_path = f"./{test_dir}/toolchest/s3/"

--- a/tests/test_kraken2.py
+++ b/tests/test_kraken2.py
@@ -83,7 +83,7 @@ def test_kraken2_s3():
     )
 
     toolchest.kraken2(
-        inputs="s3://toolchest-integration-tests-public/synthetic_bacteroides_reads.fasta",
+        inputs="s3://toolchest-integration-tests/synthetic_bacteroides_reads.fasta",
         output_path=output_dir_path,
     )
 

--- a/tests/test_megahit.py
+++ b/tests/test_megahit.py
@@ -28,14 +28,14 @@ def test_megahit_many_types():
 
     toolchest.megahit(
         interleaved=[
-            "s3://toolchest-integration-tests-public/megahit/r1.il.fa.gz",
-            "s3://toolchest-integration-tests-public/megahit/r2.il.fa.bz2",
+            "s3://toolchest-integration-tests/megahit/r1.il.fa.gz",
+            "s3://toolchest-integration-tests/megahit/r2.il.fa.bz2",
         ],
-        read_one="s3://toolchest-integration-tests-public/megahit/r3_1.fa",
-        read_two="s3://toolchest-integration-tests-public/megahit/r3_2.fa",
+        read_one="s3://toolchest-integration-tests/megahit/r3_1.fa",
+        read_two="s3://toolchest-integration-tests/megahit/r3_2.fa",
         single_end=[
-            "s3://toolchest-integration-tests-public/megahit/r4.fa",
-            "s3://toolchest-integration-tests-public/megahit/loop.fa",
+            "s3://toolchest-integration-tests/megahit/r4.fa",
+            "s3://toolchest-integration-tests/megahit/loop.fa",
         ],
         tool_args="--presets meta-large",
         output_path=output_dir_path,
@@ -60,12 +60,12 @@ def test_megahit_multiple_pairs():
 
     toolchest.megahit(
         read_one=[
-            "s3://toolchest-integration-tests-public/megahit/r3_1.fa",
-            "s3://toolchest-integration-tests-public/r1.fastq.gz",
+            "s3://toolchest-integration-tests/megahit/r3_1.fa",
+            "s3://toolchest-integration-tests/r1.fastq.gz",
         ],
         read_two=[
-            "s3://toolchest-integration-tests-public/megahit/r3_2.fa",
-            "s3://toolchest-integration-tests-public/r2.fastq.gz",
+            "s3://toolchest-integration-tests/megahit/r3_2.fa",
+            "s3://toolchest-integration-tests/r2.fastq.gz",
         ],
         tool_args="--presets meta-large",
         output_path=output_dir_path,


### PR DESCRIPTION
Redirects integration test file downloads to the private bucket, in preparation for deprecating the public bucket.