### PR TITLE
feat: add function to call api file size endpoint after s3 upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.8.0"
+version = "0.8.3"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.8.2"
+version = "0.8.3"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -19,7 +19,7 @@ from requests.exceptions import HTTPError
 
 from toolchest_client.api.auth import get_headers
 from toolchest_client.api.exceptions import ToolchestDownloadError
-from toolchest_client.api.urls import PIPELINE_URL
+from toolchest_client.api.urls import PIPELINE_SEGMENT_INSTANCES_URL
 from toolchest_client.files import get_file_type, get_params_from_s3_uri, unpack_files
 
 
@@ -90,7 +90,7 @@ def get_download_details(pipeline_segment_instance_id):
     """Gets S3 URI and access keys for downloading output of query task(s)."""
 
     response = requests.get(
-        "/".join([PIPELINE_URL, pipeline_segment_instance_id, "downloads"]),
+        "/".join([PIPELINE_SEGMENT_INSTANCES_URL, pipeline_segment_instance_id, "downloads"]),
         headers=get_headers(),
     )
     try:

--- a/toolchest_client/api/urls.py
+++ b/toolchest_client/api/urls.py
@@ -11,8 +11,8 @@ import os
 # Base URLs used by the server API.
 BASE_URL = os.environ.get("BASE_URL", "https://api.toolche.st")
 
-PIPELINE_ROUTE = "/pipeline-segment-instances"
-PIPELINE_URL = BASE_URL + PIPELINE_ROUTE
+PIPELINE_SEGMENT_INSTANCES_ROUTE = "/pipeline-segment-instances"
+PIPELINE_SEGMENT_INSTANCES_URL = BASE_URL + PIPELINE_SEGMENT_INSTANCES_ROUTE
 
 S3_ROUTE = "/s3"
 S3_URL = BASE_URL + S3_ROUTE


### PR DESCRIPTION
Updates the add input file response with a file id and then calls a new api endpoint to set the file size in the DB after uploading the file to s3.