### PR TITLE
chore: refactor `PIPELINE_URL` and `_add_input_file()`

### DIFF
--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -19,7 +19,7 @@ from requests.exceptions import HTTPError
 
 from toolchest_client.api.auth import get_headers
 from toolchest_client.api.exceptions import ToolchestDownloadError
-from toolchest_client.api.urls import PIPELINE_URL
+from toolchest_client.api.urls import PIPELINE_SEGMENT_INSTANCES_URL
 from toolchest_client.files import get_file_type, get_params_from_s3_uri, unpack_files
 
 
@@ -90,7 +90,7 @@ def get_download_details(pipeline_segment_instance_id):
     """Gets S3 URI and access keys for downloading output of query task(s)."""
 
     response = requests.get(
-        "/".join([PIPELINE_URL, pipeline_segment_instance_id, "downloads"]),
+        "/".join([PIPELINE_SEGMENT_INSTANCES_URL, pipeline_segment_instance_id, "downloads"]),
         headers=get_headers(),
     )
     try:

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -20,7 +20,7 @@ from toolchest_client.api.auth import get_headers
 from toolchest_client.api.download import download, get_download_details
 from toolchest_client.api.exceptions import ToolchestJobError, ToolchestException, ToolchestDownloadError
 from toolchest_client.api.output import Output
-from toolchest_client.api.urls import PIPELINE_URL
+from toolchest_client.api.urls import PIPELINE_SEGMENT_INSTANCES_URL
 from toolchest_client.files import OutputType, path_is_s3_uri
 from .status import Status, ThreadStatus
 
@@ -41,7 +41,7 @@ class Query:
     def __init__(self, stored_output=None):
         self.HEADERS = dict()
         self.PIPELINE_SEGMENT_INSTANCE_ID = ''
-        self.PIPELINE_SEGMENT_URL = ''
+        self.PIPELINE_SEGMENT_INSTANCE_URL = ''
         self.STATUS_URL = ''
         self.mark_as_failed = False
         self.thread_name = ''
@@ -91,12 +91,12 @@ class Query:
         self._update_thread_status(ThreadStatus.INITIALIZED)
 
         self.PIPELINE_SEGMENT_INSTANCE_ID = create_content["id"]
-        self.PIPELINE_SEGMENT_URL = "/".join([
-            PIPELINE_URL,
+        self.PIPELINE_SEGMENT_INSTANCE_URL = "/".join([
+            PIPELINE_SEGMENT_INSTANCES_URL,
             self.PIPELINE_SEGMENT_INSTANCE_ID
         ])
         self.STATUS_URL = "/".join([
-            self.PIPELINE_SEGMENT_URL,
+            self.PIPELINE_SEGMENT_INSTANCE_URL,
             "status",
         ])
         self.mark_as_failed = True
@@ -138,7 +138,7 @@ class Query:
         }
 
         create_response = requests.post(
-            PIPELINE_URL,
+            PIPELINE_SEGMENT_INSTANCES_URL,
             headers=self.HEADERS,
             json=create_body,
         )
@@ -154,7 +154,7 @@ class Query:
     # TODO: Deprecate this after confirming it doesn't affect the API.
     def _add_input_file(self, input_file_path, input_prefix, input_order, input_is_in_s3=False):
         add_input_file_url = "/".join([
-            self.PIPELINE_SEGMENT_URL,
+            self.PIPELINE_SEGMENT_INSTANCE_URL,
             'input-files'
         ])
         file_name = ntpath.basename(input_file_path)

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -165,7 +165,6 @@ class Query:
                 "file_name": file_name,
                 "tool_prefix": input_prefix,
                 "tool_prefix_order": input_order,
-                "is_s3": input_is_in_s3,
                 "s3_uri": input_file_path if input_is_in_s3 else None,
             },
         )

--- a/toolchest_client/api/urls.py
+++ b/toolchest_client/api/urls.py
@@ -11,8 +11,8 @@ import os
 # Base URLs used by the server API.
 BASE_URL = os.environ.get("BASE_URL", "https://api.toolche.st")
 
-PIPELINE_ROUTE = "/pipeline-segment-instances"
-PIPELINE_URL = BASE_URL + PIPELINE_ROUTE
+PIPELINE_SEGMENT_INSTANCES_ROUTE = "/pipeline-segment-instances"
+PIPELINE_SEGMENT_INSTANCES_URL = BASE_URL + PIPELINE_SEGMENT_INSTANCES_ROUTE
 
 S3_ROUTE = "/s3"
 S3_URL = BASE_URL + S3_ROUTE


### PR DESCRIPTION
Modifies:
*  In `api/query.py`, renames `_add_input_file()` to `_register_input_file()`.
* Deprecates including `is_s3` in `_register_input_file()`, which is unnecessary with `s3_uri`.
* Renames the confusing variable `PIPELINE_URL` to `PIPELINE_SEGMENT_INSTANCES_URL`.
* Removes stray comments in `_register_input_file()`.

Note: This can be merged into #94 directly. We should let integration tests run if merging to staging instead, but I'd hold off on updating to `0.8.1` until #94 is merged.

