### PR TITLE
feat: add support for outputting to an s3 bucket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.8.0"
+version = "0.8.1"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -85,6 +85,7 @@ class Query:
             tool_name=tool_name,
             tool_version=tool_version,
             tool_args=tool_args,
+            output_file_path=output_path
         )
         create_content = create_response.json()
 
@@ -121,7 +122,7 @@ class Query:
 
     def _send_initial_request(self, tool_name, tool_version, tool_args,
                               database_name, database_version, output_name,
-                              compress_output):
+                              compress_output, output_file_path):
         """Sends the initial request to the Toolchest API to create the query.
 
         Returns the response from the POST request.
@@ -135,6 +136,7 @@ class Query:
             "output_file_name": output_name,
             "tool_name": tool_name,
             "tool_version": tool_version,
+            "output_file_path": output_file_path,
         }
 
         create_response = requests.post(
@@ -339,7 +341,7 @@ class Query:
 
         try:
             self.output_s3_uri, output_file_keys = get_download_details(self.PIPELINE_SEGMENT_INSTANCE_ID)
-            if output_path:
+            if output_path and not path_is_s3_uri(output_path):
                 self._update_thread_status(ThreadStatus.DOWNLOADING)
                 self._update_status(Status.TRANSFERRING_TO_CLIENT)
                 self.unpacked_output_paths = download(

--- a/toolchest_client/files/unpack.py
+++ b/toolchest_client/files/unpack.py
@@ -8,6 +8,7 @@ class OutputType(Enum):
     GZ_TAR = ".tar.gz"
     FLAT_TEXT = ".txt"
     SAM_FILE = ".sam"
+    S3 = ""
 
 
 def unpack_files(file_path_to_unpack, output_type):
@@ -18,6 +19,8 @@ def unpack_files(file_path_to_unpack, output_type):
     if output_type == OutputType.FLAT_TEXT:
         return file_path_to_unpack
     elif output_type == OutputType.SAM_FILE:
+        return file_path_to_unpack
+    elif output_type == OutputType.S3:
         return file_path_to_unpack
     elif output_type == OutputType.GZ_TAR:
         # Get names of files in archive

--- a/toolchest_client/tools/kraken2.py
+++ b/toolchest_client/tools/kraken2.py
@@ -6,6 +6,7 @@ This is the Kraken2 implementation of the Tool class.
 """
 from . import Tool
 from toolchest_client.files import OutputType
+from toolchest_client.files.s3 import path_is_s3_uri
 
 
 class Kraken2(Tool):
@@ -26,7 +27,7 @@ class Kraken2(Tool):
             database_name=database_name,
             database_version=database_version,
             parallel_enabled=False,
-            output_type=OutputType.GZ_TAR,
+            output_type=OutputType.S3 if path_is_s3_uri(output_path) else OutputType.GZ_TAR,
             output_is_directory=True,
             output_names=["kraken2_output.txt", "kraken2_report.txt"]
         )


### PR DESCRIPTION
Allows the output path of a tool to be an s3 bucket that the worker nodes have permission to access.  Also adds s3 output type to kraken2 which will skip output compression.