### PR TITLE
fix: add support for a None-valued output_path

### DIFF
--- a/toolchest_client/files/s3.py
+++ b/toolchest_client/files/s3.py
@@ -87,7 +87,7 @@ def path_is_s3_uri(path):
     # Note: this is just a prefix check and does not validate whether
     #       a file exists at the given URI.
     S3_PREFIX = "s3://"
-    return path.startswith(S3_PREFIX)
+    return path and path.startswith(S3_PREFIX)
 
 
 def inputs_are_in_s3(input_paths):


### PR DESCRIPTION
Adds handling in `path_is_s3_uri` for a `None` value for `path`. Fixes test `test_kraken2_output_manual_download`.