### PR TITLE
feat: create folders along given output path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.8.3"
+version = "0.8.4"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/tests/test_cellranger.py
+++ b/tests/test_cellranger.py
@@ -14,7 +14,6 @@ if toolchest_api_key:
 def test_cellranger_count_s3_inputs():
     test_dir = "test_cellranger_count_s3_inputs"
     output_dir_path = f"./{test_dir}/output/"
-    os.makedirs(output_dir_path, exist_ok=True)
 
     # Test using a compressed archive in S3
     output = toolchest.cellranger_count(
@@ -30,7 +29,6 @@ def test_cellranger_count_local_inputs():
     input_dir_path = f"./{test_dir}/inputs/"
     output_dir_path = f"./{test_dir}/output/"
     os.makedirs(input_dir_path, exist_ok=True)
-    os.makedirs(output_dir_path, exist_ok=True)
 
     # Test from a directory of local inputs
     packed_inputs_path = f"./{test_dir}/inputs.tar.gz"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -25,8 +25,6 @@ def test_kraken2_output_manual_download():
     toolchest_s3_file_path = f"{toolchest_s3_dir_path}kraken2_output.txt"
     toolchest_pipeline_dir_path = f"./{test_dir}/toolchest/id/"
     toolchest_pipeline_file_path = f"{toolchest_pipeline_dir_path}kraken2_output.txt"
-    for dir_path in [manual_output_dir_path, toolchest_s3_dir_path, toolchest_pipeline_dir_path]:
-        os.makedirs(f"./{dir_path}", exist_ok=True)
 
     # Run job without downloading
     output = toolchest.kraken2(

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -33,8 +33,7 @@ def download(output_path, s3_uri=None, pipeline_segment_instance_id=None,
     `get_download_details()`.
 
     :param output_path: Output path to which the file(s) will be downloaded.
-        This should be a directory that already exists, but direct filenames
-        are also supported.
+        This should be a directory, but direct filenames are also supported.
     :param s3_uri: URI of file contained in S3. This can be passed from
         the parameter `output.s3_uri` from the `output` returned by a previous
         job.
@@ -45,6 +44,7 @@ def download(output_path, s3_uri=None, pipeline_segment_instance_id=None,
     :param skip_decompression: Whether to skip decompression of the downloaded file archive.
     :param output_type: Output type of the produced output file. Used internally.
     """
+    # TODO: support output_path directory creation while supporting non-directory filetypes
 
     if output_file_keys is None:
         if s3_uri:

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -33,7 +33,7 @@ def download(output_path, s3_uri=None, pipeline_segment_instance_id=None,
     `get_download_details()`.
 
     :param output_path: Output path to which the file(s) will be downloaded.
-        This should be a directory, but direct filenames are also supported.
+        This should be a local directory, but direct filenames are also supported.
     :param s3_uri: URI of file contained in S3. This can be passed from
         the parameter `output.s3_uri` from the `output` returned by a previous
         job.
@@ -44,7 +44,6 @@ def download(output_path, s3_uri=None, pipeline_segment_instance_id=None,
     :param skip_decompression: Whether to skip decompression of the downloaded file archive.
     :param output_type: Output type of the produced output file. Used internally.
     """
-    # TODO: support output_path directory creation while supporting non-directory filetypes
 
     if output_file_keys is None:
         if s3_uri:
@@ -57,6 +56,13 @@ def download(output_path, s3_uri=None, pipeline_segment_instance_id=None,
         else:
             error_message = "S3 URI of output not provided."
             raise ToolchestDownloadError(error_message) from None
+
+    # Create output directories if output_path does not exist.
+    # Note: Assumes that output_path is a directory if it does not exist.
+    # This may lead to undesired leaf dir creation if output_path is not intended to be a dir,
+    # but support for non-dir output_path will likely be deprecated.
+    if not os.path.exists(output_path) and output_type is None:
+        os.makedirs(output_path, exist_ok=True)
 
     # If output_path is a directory, extract the filename from the target download.
     if os.path.isdir(output_path):

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -8,7 +8,7 @@ the Toolchest server, given access to an API key.
 Note: This module is used in downloading from the Output and
 Query classes.
 """
-
+import logging
 import os
 import sys
 
@@ -61,7 +61,10 @@ def download(output_path, s3_uri=None, pipeline_segment_instance_id=None,
     # Note: Assumes that output_path is a directory if it does not exist.
     # This may lead to undesired leaf dir creation if output_path is not intended to be a dir,
     # but support for non-dir output_path will likely be deprecated.
+    output_path = os.path.abspath(output_path)
     if not os.path.exists(output_path) and output_type is None:
+        if "." in os.path.basename(output_path):
+            logging.warning(f"Creating {os.path.basename(output_path)} as a directory along path {output_path}")
         os.makedirs(output_path, exist_ok=True)
 
     # If output_path is a directory, extract the filename from the target download.

--- a/toolchest_client/tools/cellranger.py
+++ b/toolchest_client/tools/cellranger.py
@@ -5,6 +5,7 @@ toolchest_client.tools.cellranger
 This contains the cellranger implementations of the Tool class.
 """
 from . import Tool
+from toolchest_client.files import OutputType
 
 
 class CellRangerCount(Tool):
@@ -26,5 +27,6 @@ class CellRangerCount(Tool):
             database_version=database_version,
             compress_inputs=True,
             max_input_bytes_per_file=128 * 1024 * 1024 * 1024,
+            output_type=OutputType.GZ_TAR,
             output_is_directory=True,
         )

--- a/toolchest_client/tools/cellranger.py
+++ b/toolchest_client/tools/cellranger.py
@@ -26,4 +26,5 @@ class CellRangerCount(Tool):
             database_version=database_version,
             compress_inputs=True,
             max_input_bytes_per_file=128 * 1024 * 1024 * 1024,
+            output_is_directory=True,
         )

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -96,7 +96,7 @@ class Tool:
             raise ValueError(f"Too many input files submitted. "
                              f"Maximum is {self.max_inputs}, {self.num_input_files} found.")
 
-    def _is_local_path(self):
+    def _output_path_is_local(self):
         return self.output_path and not path_is_s3_uri(self.output_path)
 
     def _validate_tool_args(self):
@@ -193,7 +193,7 @@ class Tool:
 
         if self.inputs is None:
             raise ValueError("No input provided.")
-        if self._is_local_path() and not os.access(
+        if self._output_path_is_local() and not os.access(
                 os.path.dirname(self.output_path),
                 os.W_OK | os.X_OK,
         ):
@@ -219,7 +219,7 @@ class Tool:
 
         # Check if the given output_path is a directory, if required by the tool
         # and if the user provides output_path.
-        if self._is_local_path():
+        if self._output_path_is_local():
             if self.output_is_directory:
                 if os.path.exists(self.output_path):
                     if os.path.isfile(self.output_path):
@@ -235,7 +235,7 @@ class Tool:
 
     def _postflight(self):
         """Generic postflight check. Tools can have more specific implementations."""
-        if self._is_local_path():
+        if self._output_path_is_local():
             if self.output_validation_enabled:
                 for output_name in self.output_names:
                     output_file_path = f"{self.output_path}/{output_name}"
@@ -394,7 +394,7 @@ class Tool:
         temp_input_file_paths = []
         temp_output_file_paths = []
         non_parallel_output_path = f"{self.output_path}/{self.output_name}" if self.output_is_directory \
-            and self._is_local_path() else self.output_path
+            and self._output_path_is_local() else self.output_path
         for thread_index, input_files in enumerate(jobs):
             # Add split files for merging and later deletion, if running in parallel
             # TODO: handle parallel output for s3 uri

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -35,7 +35,7 @@ class Tool:
                  max_input_bytes_per_file=FOUR_POINT_FIVE_GIGABYTES,
                  max_input_bytes_per_file_parallel=FOUR_POINT_FIVE_GIGABYTES,
                  group_paired_ends=False, compress_inputs=False,
-                 output_type=OutputType.FLAT_TEXT, output_is_directory=False,
+                 output_type=OutputType.FLAT_TEXT, output_is_directory=True,
                  output_names=None):
         self.tool_name = tool_name
         self.tool_version = tool_version
@@ -225,7 +225,9 @@ class Tool:
                             f"{self.output_path} is a file. Please pass a directory instead of an output file."
                         )
                 else:
-                    os.makedirs(self.output_path)
+                    os.makedirs(self.output_path, exist_ok=True)
+            else:
+                os.makedirs(os.path.dirname(self.output_path), exist_ok=True)
 
             self._warn_if_outputs_exist()
 

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -41,7 +41,7 @@ class Tool:
         self.tool_version = tool_version
         self.tool_args = tool_args
         self.output_name = output_name
-        self.output_path = output_path
+        self.output_path = os.path.abspath(output_path)
         self.output_is_directory = output_is_directory
         self.inputs = inputs
         # input_prefix_mapping is a dict in the shape of:

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -196,8 +196,6 @@ class Tool:
             raise OSError("Output file path must be writable.")
         if not self.output_name:
             raise ValueError("Output name must be non-empty.")
-        if self.output_is_directory and self.output_path and not os.path.isdir(self.output_path):
-            raise ValueError(f"Output path must be a directory. It is currently {self.output_path}")
 
     def _merge_outputs(self, output_file_paths):
         """Merges output files for parallel runs."""


### PR DESCRIPTION
Adds:
- Output path directory creation if `output_path` does not exist, both in tool runs and manual download.

Modifies:
- `_validate_args` in the `Tool` class no longer checks existence of the output directory.
- Integration tests (where applicable) no longer create an output dir before running a tool or downloading.
- `_is_local_path` is renamed to `_output_path_is_local`