### PR TITLE
feat: custom S3 database support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.8.1"
+version = "0.8.2"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/tests/test_kraken2.py
+++ b/tests/test_kraken2.py
@@ -73,14 +73,8 @@ def test_kraken2_s3():
     """
     test_dir = "test_kraken2_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
-    input_file_path = "./kraken_input.fasta"
     output_dir_path = f"./{test_dir}/"
     output_file_path = f"{output_dir_path}kraken2_output.txt"
-
-    s3.download_integration_test_input(
-        s3_file_key="synthetic_bacteroides_reads.fasta",
-        output_file_path=input_file_path,
-    )
 
     toolchest.kraken2(
         inputs="s3://toolchest-integration-tests/synthetic_bacteroides_reads.fasta",
@@ -88,3 +82,25 @@ def test_kraken2_s3():
     )
 
     assert hash.unordered(output_file_path) == KRAKEN2_SINGLE_END_HASH
+
+
+@pytest.mark.integration
+def test_kraken2_custom_db():
+    """
+    Tests Kraken 2 with an example custom database (viral refseq index)
+    """
+    KRAKEN2_OUTPUT_VIRAL_HASH = 1003212151
+
+    test_dir = "test_kraken2_custom_db"
+    os.makedirs(f"./{test_dir}", exist_ok=True)
+    output_dir_path = f"./{test_dir}/"
+    output_file_path = f"{output_dir_path}kraken2_output.txt"
+
+    custom_db = "s3://toolchest-fsx-databases/kraken2/k2_viral_20210517/"
+    toolchest.kraken2(
+        read_one="s3://toolchest-integration-tests/synthetic_bacteroides_reads.fasta",
+        custom_database_path=custom_db,
+        output_path=output_dir_path,
+    )
+
+    assert hash.unordered(output_file_path) == KRAKEN2_OUTPUT_VIRAL_HASH

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -52,7 +52,7 @@ class Query:
 
     def run_query(self, tool_name, tool_version, input_prefix_mapping,
                   output_type, tool_args=None, database_name=None, database_version=None,
-                  output_name="output", input_files=None,
+                  custom_database_path=None, output_name="output", input_files=None,
                   output_path=None, thread_statuses=None):
         """Executes a query to the Toolchest API.
 
@@ -61,6 +61,7 @@ class Query:
         :param tool_args: Tool-specific arguments to be passed to the tool.
         :param database_name: Name of database to be used.
         :param database_version: Version of database to be used.
+        :param custom_database_path: Path (S3 URI) to a custom database.
         :param input_prefix_mapping: Mapping of input filepaths to associated prefix tags (e.g., "-1")
         :param output_name: (optional) Internal name of file outputted by the tool.
         :param input_files: List of paths to be passed in as input.
@@ -81,11 +82,12 @@ class Query:
             compress_output=True if output_type == OutputType.GZ_TAR else False,
             database_name=database_name,
             database_version=database_version,
+            custom_database_path=custom_database_path,
             output_name=output_name,
             tool_name=tool_name,
             tool_version=tool_version,
             tool_args=tool_args,
-            output_file_path=output_path
+            output_file_path=output_path,
         )
         create_content = create_response.json()
 
@@ -121,8 +123,8 @@ class Query:
         return self.output
 
     def _send_initial_request(self, tool_name, tool_version, tool_args,
-                              database_name, database_version, output_name,
-                              compress_output, output_file_path):
+                              database_name, database_version, custom_database_path,
+                              output_name, compress_output, output_file_path):
         """Sends the initial request to the Toolchest API to create the query.
 
         Returns the response from the POST request.
@@ -131,6 +133,7 @@ class Query:
         create_body = {
             "compress_output": compress_output,
             "custom_tool_args": tool_args,
+            "custom_database_s3_location": custom_database_path,
             "database_name": database_name,
             "database_version": database_version,
             "output_file_name": output_name,

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -79,7 +79,7 @@ def cellranger_count(inputs, database_name="GRCh38", output_path=None, tool_args
 
 
 def kraken2(output_path=None, inputs=[], database_name="standard", database_version="1",
-            tool_args="", read_one=None, read_two=None):
+            tool_args="", read_one=None, read_two=None, custom_database_path=None):
     """Runs Kraken 2 via Toolchest.
 
     :param inputs: Path or list of paths (client-side) to be passed in as input(s).
@@ -88,6 +88,8 @@ def kraken2(output_path=None, inputs=[], database_name="standard", database_vers
     :param database_name: (optional) Name of database to use for Kraken 2 alignment. Defaults to standard DB.
     :param database_version: (optional) Version of database to use for Kraken 2 alignment. Defaults to 1.
     :type database_version: str
+    :param custom_database_path: (optional) Path to a custom database.
+    This must be an AWS S3 URI accessible from Toolchest.
     :param read_one: (optional) Path to read 1 of paired-read input files.
     :param read_two: (optional) Path to read 2 of paired-read input files.
 
@@ -98,6 +100,9 @@ def kraken2(output_path=None, inputs=[], database_name="standard", database_vers
 
      If using `read_one` and `read_two`, these will be interpreted as the input files
      over anything given in `inputs`.
+
+     If using `custom_database_path`, the given database will supersede any database
+     selected via `database_name` and `database_version`.
 
     Usage::
 
@@ -134,6 +139,7 @@ def kraken2(output_path=None, inputs=[], database_name="standard", database_vers
         output_path=output_path,
         database_name=database_name,
         database_version=database_version,
+        custom_database_path=custom_database_path,
     )
     output = instance.run()
     return output

--- a/toolchest_client/tools/kraken2.py
+++ b/toolchest_client/tools/kraken2.py
@@ -14,7 +14,7 @@ class Kraken2(Tool):
     The Kraken2 implementation of the Tool class.
     """
     def __init__(self, tool_args, output_name, inputs, output_path,
-                 database_name, database_version):
+                 database_name, database_version, custom_database_path):
         super().__init__(
             tool_name="kraken2",
             tool_version="2.1.1",  # todo: allow kraken 2 version to be set by the user
@@ -26,6 +26,7 @@ class Kraken2(Tool):
             max_inputs=2,
             database_name=database_name,
             database_version=database_version,
+            custom_database_path=custom_database_path,
             parallel_enabled=False,
             output_type=OutputType.S3 if path_is_s3_uri(output_path) else OutputType.GZ_TAR,
             output_is_directory=True,

--- a/toolchest_client/tools/tests/test_kraken2.py
+++ b/toolchest_client/tools/tests/test_kraken2.py
@@ -14,6 +14,7 @@ def test_kraken2_preflight():
         output_path=output_path,
         database_name="standard",
         database_version=1,
+        custom_database_path=None,
     )
     kraken_instance._preflight()
 

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -414,6 +414,7 @@ class Tool:
                 "tool_args": self.tool_args,
                 "database_name": self.database_name,
                 "database_version": self.database_version,
+                "custom_database_path": self.custom_database_path,
                 "output_name": f"{thread_index}_{self.output_name}" if should_run_in_parallel else self.output_name,
                 "input_files": input_files,
                 "input_prefix_mapping": self.input_prefix_mapping,

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -30,7 +30,7 @@ FOUR_POINT_FIVE_GIGABYTES = int(4.5 * 1024 * 1024 * 1024)
 class Tool:
     def __init__(self, tool_name, tool_version, tool_args, output_name,
                  inputs, min_inputs, max_inputs=None, output_path=None,
-                 database_name=None, database_version=None,
+                 database_name=None, database_version=None, custom_database_path=None,
                  input_prefix_mapping=None, parallel_enabled=False,
                  max_input_bytes_per_file=FOUR_POINT_FIVE_GIGABYTES,
                  max_input_bytes_per_file_parallel=FOUR_POINT_FIVE_GIGABYTES,
@@ -58,6 +58,7 @@ class Tool:
         self.max_inputs = max_inputs
         self.database_name = database_name
         self.database_version = database_version
+        self.custom_database_path = custom_database_path
         self.parallel_enabled = parallel_enabled
         self.output_validation_enabled = True
         self.group_paired_ends = group_paired_ends


### PR DESCRIPTION
Adds:
- Support for custom databases, specified by the `custom_database_path` argument for `toolchest.kraken2()`. (Custom DBs are only enabled for `kraken2`.)
  - A custom database path must be given as an AWS S3 URI that must be accessible from Toolchest.
- Integration test for custom databases.

Modifies:
- The `test_kraken2_s3` integration test no longer unnecessarily downloads the input to local storage.