### PR TITLE
fix: set default version number

### DIFF
--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -10,7 +10,10 @@ try:
     import importlib.metadata as importlib_metadata
 except ImportError:
     import importlib_metadata as importlib_metadata
-__version__ = importlib_metadata.version(__package__ or __name__)
+try:
+    __version__ = importlib_metadata.version(__package__ or __name__)
+except importlib_metadata.PackageNotFoundError:
+    __version__ = "0.0.0";
 
 # .env load must be before imports that use environment variables
 load_dotenv(find_dotenv(".env"))

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -13,7 +13,7 @@ except ImportError:
 try:
     __version__ = importlib_metadata.version(__package__ or __name__)
 except importlib_metadata.PackageNotFoundError:
-    __version__ = "0.0.0";
+    __version__ = "0.0.0"
 
 # .env load must be before imports that use environment variables
 load_dotenv(find_dotenv(".env"))

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -13,7 +13,7 @@ except ImportError:
 try:
     __version__ = importlib_metadata.version(__package__ or __name__)
 except importlib_metadata.PackageNotFoundError:
-    __version__ = "0.0.0"
+    __version__ = None
 
 # .env load must be before imports that use environment variables
 load_dotenv(find_dotenv(".env"))


### PR DESCRIPTION
Sets the version number to a default instead of erroring if the client is run from source (i.e., without the `toolchest-client` package being installed via pip).

Open question: the version number defaults to `0.0.0`, which can be confusing -- are there any other labels that might be better (e.g., `dev` or just the empty string)?