### PR TITLE
fix: abspath + parallel output check for tests

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -37,19 +37,19 @@ def test_kraken2_output_manual_download():
     # If multiple files are returned, path_from_manual download will be a list,
     # so we simply check if kraken2_output.txt is contained in it
     if isinstance(path_from_manual_download, list):
-        path_from_manual_download = [os.path.normpath(path) for path in path_from_manual_download]
+        path_from_manual_download = [os.path.abspath(path) for path in path_from_manual_download]
     else:
         path_from_manual_download = [path_from_manual_download]
-    assert os.path.normpath(manual_output_file_path) in path_from_manual_download
+    assert os.path.abspath(manual_output_file_path) in path_from_manual_download
     assert hash.unordered(manual_output_file_path) == KRAKEN2_SINGLE_END_HASH
 
     # Test again with toolchest.download(), using S3 URI
     path_from_toolchest_download = toolchest.download(toolchest_s3_dir_path, s3_uri=output.s3_uri)
     if isinstance(path_from_toolchest_download, list):
-        path_from_toolchest_download = [os.path.normpath(path) for path in path_from_toolchest_download]
+        path_from_toolchest_download = [os.path.abspath(path) for path in path_from_toolchest_download]
     else:
         path_from_toolchest_download = [path_from_toolchest_download]
-    assert os.path.normpath(toolchest_s3_file_path) in path_from_toolchest_download
+    assert os.path.abspath(toolchest_s3_file_path) in path_from_toolchest_download
     assert hash.unordered(toolchest_s3_file_path) == KRAKEN2_SINGLE_END_HASH
 
     # Test again with toolchest.download(), using pipeline segment instance ID
@@ -60,8 +60,8 @@ def test_kraken2_output_manual_download():
         pipeline_segment_instance_id=pipeline_segment_instance_id,
     )
     if isinstance(path_from_toolchest_download, list):
-        path_from_toolchest_download = [os.path.normpath(path) for path in path_from_toolchest_download]
+        path_from_toolchest_download = [os.path.abspath(path) for path in path_from_toolchest_download]
     else:
         path_from_toolchest_download = [path_from_toolchest_download]
-    assert os.path.normpath(toolchest_pipeline_file_path) in path_from_toolchest_download
+    assert os.path.abspath(toolchest_pipeline_file_path) in path_from_toolchest_download
     assert hash.unordered(toolchest_pipeline_file_path) == KRAKEN2_SINGLE_END_HASH

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -231,10 +231,9 @@ class Tool:
                         )
                 else:
                     os.makedirs(self.output_path, exist_ok=True)
+                self._warn_if_outputs_exist()
             else:
                 os.makedirs(os.path.dirname(self.output_path), exist_ok=True)
-
-            self._warn_if_outputs_exist()
 
     def _postflight(self, output):
         """Generic postflight check. Tools can have more specific implementations."""
@@ -246,9 +245,12 @@ class Tool:
         elif self._output_path_is_local():
             if self.output_validation_enabled:
                 print("Checking output...")
-                for output_name in self.output_names:
-                    output_file_path = f"{self.output_path}/{output_name}"
-                    sanity_check(output_file_path)
+                if self.output_is_directory:
+                    for output_name in self.output_names:
+                        output_file_path = f"{self.output_path}/{output_name}"
+                        sanity_check(output_file_path)
+                else:
+                    sanity_check(self.output_path)
             print(f"\nYour Toolchest run is complete! The run ID and output locations are included in the return.\n\n"
                   f"If you need to re-download the results, run download(run_id=\"{output.run_id}\") within 7 days\n"
                   )


### PR DESCRIPTION
Modifies:
- path checking for `test_kraken2_output_manual_download` 
- output validation for parallelization tests