### PR TITLE
fix: remove pysam due to multiple issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ boto3 = "^1.18.29"
 python = "^3.6"
 requests = "^2.25.1"
 python-dotenv = "^0.18.0"
-pysam = { version = "^0.18.0", markers = "sys_platform == 'linux' or sys_platform == 'darwin'" }
 importlib-metadata = { version = "~=1.0", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -37,6 +37,7 @@ def test_star_grch38():
 
 
 @pytest.mark.integration
+@pytest.mark.skip(reason="Pysam removed so parallelization is disabled until a new sam file merger is written or found")
 def test_star_grch38_parallel():
     """
     Tests STAR against the grch38 database, using parallel mode


### PR DESCRIPTION
Pysam has caused multiple issues as a package and STAR parallelization is not currently used so this pr fully removes pysam as a dependency. Either a different library or custom sam file merging code is planned to be implemented later so parallelization framework is remaining in the code for now.