### PR TITLE
fix: remove writable dir check before creation

### DIFF
--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -198,11 +198,6 @@ class Tool:
 
         if self.inputs is None:
             raise ValueError("No input provided.")
-        if self._output_path_is_local() and not os.access(
-                os.path.dirname(self.output_path),
-                os.W_OK | os.X_OK,
-        ):
-            raise OSError("Output file path must be writable.")
         if not self.output_name:
             raise ValueError("Output name must be non-empty.")
 

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -198,6 +198,8 @@ class Tool:
 
         if self.inputs is None:
             raise ValueError("No input provided.")
+        if self._output_path_is_local() and self.output_path.startswith("~"):
+            raise OSError("Output file path must be an absolute path.")
         if not self.output_name:
             raise ValueError("Output name must be non-empty.")
 


### PR DESCRIPTION
Fixes the issue where appending a `/` on the output path caused the run to fail if the directory didn't already exist. Also allows for multiple directories to be created so a user can set the output path to `{existing-directory}/new/folder/for/output` and all the sub directories will be created.