### PR TITLE
fix: add check for interrupted/failed threads

### DIFF
--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -452,9 +452,8 @@ class Tool:
         self._wait_for_threads_to_finish()
 
         # Check for interrupted or failed threads
-        if ThreadStatus.INTERRUPTING in self.query_thread_statuses.values() \
-            or ThreadStatus.FAILED in self.query_thread_statuses.values() \
-                or self.terminating:
+        run_failed = not all(status == ThreadStatus.COMPLETE for status in self.query_thread_statuses.values())
+        if run_failed or self.terminating:
             run_ids = [thread_output.run_id for thread_output in self.thread_outputs]
             # Prints each run_id to a new line, surrounded by quotes, prefaced by tab
             pretty_print_run_ids = '\t\"' + '\"\n\t\"'.join(run_ids) + '\"'

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -451,6 +451,20 @@ class Tool:
 
         self._wait_for_threads_to_finish()
 
+        # Check for interrupted or failed threads
+        if ThreadStatus.INTERRUPTING in self.query_thread_statuses.values() \
+            or ThreadStatus.FAILED in self.query_thread_statuses.values() \
+                or self.terminating:
+            run_ids = [thread_output.run_id for thread_output in self.thread_outputs]
+            # Prints each run_id to a new line, surrounded by quotes, prefaced by tab
+            pretty_print_run_ids = '\t\"' + '\"\n\t\"'.join(run_ids) + '\"'
+            print(
+                "\nToolchest run failed. "
+                "For support, contact Toolchest with the error log (above) and the following details:\n\n"
+                f"run_id: \n{pretty_print_run_ids}"
+            )
+            return
+
         # Do basic check for completion, merge output files, delete temporary files
         if should_run_in_parallel:
             for temp_parallel_output_file_path in temp_output_file_paths:

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -461,7 +461,7 @@ class Tool:
             print(
                 "\nToolchest run failed. "
                 "For support, contact Toolchest with the error log (above) and the following details:\n\n"
-                f"run_id: \n{pretty_print_run_ids}"
+                f"run_id: \n{pretty_print_run_ids}\n"
             )
             return
 


### PR DESCRIPTION
Adds a check for failed threads (with a custom "run failed" printed message) at the end of a run, in order to skip the "Toolchest run complete" message if a job fails.