### PR TITLE
feat: support for public HTTP inputs

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,29 @@
+import os
+import pytest
+
+import toolchest_client as toolchest
+
+toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
+if toolchest_api_key:
+    toolchest.set_key(toolchest_api_key)
+
+
+@pytest.mark.integration2
+def test_http_input():
+    """
+    Tests test function with an http input
+    """
+    test_dir = "test_http"
+    os.makedirs(f"./{test_dir}", exist_ok=True)
+    input_file_path = "https://toolchest-public-examples-no-encryption.s3.amazonaws.com/example.fastq"
+    output_dir_path = f"./{test_dir}/"
+    output_file_path = f"{output_dir_path}output.txt"
+
+    test_output = toolchest.test(
+        inputs=input_file_path,
+        output_path=output_dir_path
+    )
+
+    with open(output_file_path, "r") as f:
+        for line in f:
+            assert line == "success"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -25,5 +25,4 @@ def test_http_input():
     )
 
     with open(output_file_path, "r") as f:
-        for line in f:
-            assert line == "success"
+        assert f.read().strip() == "success"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -17,9 +17,9 @@ def test_http_input():
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_path = "https://toolchest-public-examples-no-encryption.s3.amazonaws.com/example.fastq"
     output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}output.txt"
+    output_file_path = f"{output_dir_path}test_output.txt"
 
-    test_output = toolchest.test(
+    toolchest.test(
         inputs=input_file_path,
         output_path=output_dir_path
     )

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -8,7 +8,7 @@ if toolchest_api_key:
     toolchest.set_key(toolchest_api_key)
 
 
-@pytest.mark.integration2
+@pytest.mark.integration
 def test_http_input():
     """
     Tests test function with an http input

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -199,7 +199,7 @@ class Query:
         ])
         file_name = os.path.basename(input_file_path)
         input_is_in_s3 = path_is_s3_uri(input_file_path)
-        input_is_http_url = path_is_http_url()
+        input_is_http_url = path_is_http_url(input_file_path)
 
         response = requests.post(
             register_input_file_url,

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -6,7 +6,7 @@ This module provides a Query object to execute any queries made by Toolchest
 tools. These queries are handled by the Toolchest (server) API.
 """
 
-import ntpath
+import os
 import sys
 import threading
 import time
@@ -21,7 +21,7 @@ from toolchest_client.api.download import download, get_download_details
 from toolchest_client.api.exceptions import ToolchestJobError, ToolchestException, ToolchestDownloadError
 from toolchest_client.api.output import Output
 from toolchest_client.api.urls import PIPELINE_SEGMENT_INSTANCES_URL
-from toolchest_client.files import OutputType, path_is_s3_uri
+from toolchest_client.files import OutputType, path_is_s3_uri, path_is_http_url
 from .status import Status, ThreadStatus
 
 
@@ -174,11 +174,11 @@ class Query:
 
         return create_response
 
-    def _update_file_size(self, fileId):
+    def _update_file_size(self, file_id):
         update_file_size_url = "/".join([
             PIPELINE_SEGMENT_INSTANCES_URL,
             'input-files',
-            fileId,
+            file_id,
             'update-file-size'
         ])
 
@@ -189,7 +189,7 @@ class Query:
         try:
             response.raise_for_status()
         except HTTPError:
-            print(f"Failed to update size for file: {fileId}", file=sys.stderr)
+            print(f"Failed to update size for file: {file_id}", file=sys.stderr)
             raise
 
     def _register_input_file(self, input_file_path, input_prefix, input_order):
@@ -197,8 +197,9 @@ class Query:
             self.PIPELINE_SEGMENT_INSTANCE_URL,
             'input-files'
         ])
-        file_name = ntpath.basename(input_file_path)
+        file_name = os.path.basename(input_file_path)
         input_is_in_s3 = path_is_s3_uri(input_file_path)
+        input_is_http_url = path_is_http_url()
 
         response = requests.post(
             register_input_file_url,
@@ -208,6 +209,7 @@ class Query:
                 "tool_prefix": input_prefix,
                 "tool_prefix_order": input_order,
                 "s3_uri": input_file_path if input_is_in_s3 else None,
+                "http_url": input_file_path if input_is_http_url else None,
             },
         )
         try:
@@ -234,11 +236,12 @@ class Query:
 
         for file_path in input_file_paths:
             input_is_in_s3 = path_is_s3_uri(file_path)
+            input_is_http_url = path_is_http_url(file_path)
             input_prefix_details = input_prefix_mapping.get(file_path)
             input_prefix = input_prefix_details.get("prefix") if input_prefix_details else None
             input_order = input_prefix_details.get("order") if input_prefix_details else None
             # If the file is already in S3, there is no need to upload.
-            if input_is_in_s3:
+            if input_is_in_s3 or input_is_http_url:
                 # Registers the file in the internal DB.
                 self._register_input_file(
                     input_file_path=file_path,

--- a/toolchest_client/files/__init__.py
+++ b/toolchest_client/files/__init__.py
@@ -3,3 +3,4 @@ from .merge import concatenate_files, merge_sam_files
 from .s3 import assert_accessible_s3, get_s3_file_size, get_params_from_s3_uri, path_is_s3_uri
 from .split import open_new_output_file, split_file_by_lines, split_paired_files_by_lines
 from .unpack import OutputType, unpack_files, get_file_type
+from .http import get_url_with_protocol, path_is_http_url, get_http_url_file_size

--- a/toolchest_client/files/http.py
+++ b/toolchest_client/files/http.py
@@ -42,7 +42,4 @@ def get_http_url_file_size(url):
     """
     response = requests.head(url)
     response.raise_for_status()
-    try:
-        return int(response.json().get('content-length', 0))
-    except JSONDecodeError:
-        return 0
+    return int(response.headers.get('content-length', 0))

--- a/toolchest_client/files/http.py
+++ b/toolchest_client/files/http.py
@@ -1,0 +1,44 @@
+"""
+toolchest_client.files.http
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Functions for handling files given by HTTP / HTTPS URLs.
+"""
+from urllib.parse import urlparse
+
+import requests
+from requests.exceptions import HTTPError
+
+
+def get_url_with_protocol(url):
+    """Returns URL with `http://` prepended, if a protocol is not specified.
+
+    :param url: An input URL.
+    """
+    parsed_url = urlparse(url)
+    if not parsed_url.scheme:
+        url = "http://" + url
+    return url
+
+
+def path_is_http_url(path):
+    """Returns whether the given path is an accessible URL by sending a HEAD request.
+
+    :param path: An input path.
+    """
+    try:
+        get_http_url_file_size(get_url_with_protocol(path))
+    except HTTPError:
+        return False
+
+    return True
+
+
+def get_http_url_file_size(url):
+    """Returns file size of an accessible URL, via HEAD metadata.
+
+    :param url: An input URL.
+    """
+    response = requests.head(url)
+    return int(response.get('content-length'))
+

--- a/toolchest_client/files/http.py
+++ b/toolchest_client/files/http.py
@@ -4,6 +4,7 @@ toolchest_client.files.http
 
 Functions for handling files given by HTTP / HTTPS URLs.
 """
+from json.decoder import JSONDecodeError
 from urllib.parse import urlparse
 
 import requests
@@ -40,4 +41,8 @@ def get_http_url_file_size(url):
     :param url: An input URL.
     """
     response = requests.head(url)
-    return int(response.get('content-length'))
+    response.raise_for_status()
+    try:
+        return int(response.json().get('content-length', 0))
+    except JSONDecodeError:
+        return 0

--- a/toolchest_client/files/http.py
+++ b/toolchest_client/files/http.py
@@ -41,4 +41,3 @@ def get_http_url_file_size(url):
     """
     response = requests.head(url)
     return int(response.get('content-length'))
-

--- a/toolchest_client/files/http.py
+++ b/toolchest_client/files/http.py
@@ -4,7 +4,6 @@ toolchest_client.files.http
 
 Functions for handling files given by HTTP / HTTPS URLs.
 """
-from json.decoder import JSONDecodeError
 from urllib.parse import urlparse
 
 import requests

--- a/toolchest_client/files/http.py
+++ b/toolchest_client/files/http.py
@@ -7,7 +7,7 @@ Functions for handling files given by HTTP / HTTPS URLs.
 from urllib.parse import urlparse
 
 import requests
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, InvalidURL
 
 
 def get_url_with_protocol(url):
@@ -28,7 +28,7 @@ def path_is_http_url(path):
     """
     try:
         get_http_url_file_size(get_url_with_protocol(path))
-    except HTTPError:
+    except (InvalidURL, HTTPError):
         return False
 
     return True


### PR DESCRIPTION
Adds support for inputs that are given as publicly accessible HTTP or HTTPS URLs.

URLs are supplied in `inputs` just like a path to a local file to upload, and are handled similarly to AWS S3 URI inputs.