### PR TITLE
feat: add env to sentry init

### DIFF
--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -4,6 +4,7 @@ import builtins
 from dotenv import load_dotenv, find_dotenv
 import functools
 import sentry_sdk
+import os
 
 # set __version__ module
 try:
@@ -34,5 +35,6 @@ from .tools.api import alphafold, bowtie2, cellranger_count, clustalo, demucs, k
 sentry_sdk.init(
     "https://c7db7e7a4ac349cc974c55f1fcb7d2f7@o1171636.ingest.sentry.io/6271973",
 
-    traces_sample_rate=1.0
+    traces_sample_rate=1.0,
+    environment=os.getenv("DEPLOY_ENVIRONMENT", 'production')
 )


### PR DESCRIPTION
Devs should set `DEPLOY_ENVIRONMENT` to `staging`, `dev`, `local`, etc via their ide or `os.environ` call in their local script.