### PR TITLE
fix: reconfigure shogun_align with bowtie2

### DIFF
--- a/tests/test_chaining.py
+++ b/tests/test_chaining.py
@@ -9,7 +9,7 @@ if toolchest_api_key:
     toolchest.set_key(toolchest_api_key)
 
 SHI7_SINGLE_END_HASH = 1570879637
-SHOGUN_CHAINED_HASH = 33856653
+SHOGUN_CHAINED_HASH = 1708070294
 
 
 @pytest.mark.integration
@@ -29,7 +29,7 @@ def test_shi7_shogun_chaining():
     test_dir = "test_shi7_shogun_chaining"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}/"
-    output_file_path_shogun = f"{output_dir_path}alignment.burst.b6"
+    output_file_path_shogun = f"{output_dir_path}alignment.bowtie2.sam"
 
     output_shi7 = toolchest.shi7(
         tool_args="-SE",

--- a/tests/test_shogun.py
+++ b/tests/test_shogun.py
@@ -19,7 +19,7 @@ def test_shogun_filter_and_align():
     os.makedirs(f"{test_dir}", exist_ok=True)
     input_file_path = f"./{test_dir}/combined_seqs_unfiltered.fna"
     output_file_path_filter = f"./{test_dir}/combined_seqs.filtered.fna"
-    output_file_path_align = f"./{test_dir}/alignment.burst.b6"
+    output_file_path_align = f"./{test_dir}/alignment.bowtie2.sam"
 
     s3.download_integration_test_input(
         s3_file_key="combined_seqs_unfiltered.fna",
@@ -40,5 +40,4 @@ def test_shogun_filter_and_align():
         inputs=output_file_path_filter,
         output_path=test_dir,
     )
-
-    assert hash.unordered(output_file_path_align) == 780853697
+    assert hash.unordered(output_file_path_align) == 1952162202

--- a/toolchest_client/files/http.py
+++ b/toolchest_client/files/http.py
@@ -5,6 +5,7 @@ toolchest_client.files.http
 Functions for handling files given by HTTP / HTTPS URLs.
 """
 from urllib.parse import urlparse
+from urllib3.exceptions import LocationParseError
 
 import requests
 from requests.exceptions import HTTPError, InvalidURL, InvalidSchema
@@ -28,7 +29,7 @@ def path_is_http_url(path):
     """
     try:
         get_http_url_file_size(get_url_with_protocol(path))
-    except (InvalidURL, HTTPError, InvalidSchema):
+    except (InvalidURL, HTTPError, InvalidSchema, LocationParseError):
         return False
 
     return True

--- a/toolchest_client/tools/shogun.py
+++ b/toolchest_client/tools/shogun.py
@@ -28,7 +28,7 @@ class ShogunAlign(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_is_directory=True,
-            output_names=["alignment.burst.b6"],
+            output_names=["alignment.bowtie2.sam"],
             **kwargs,
         )
 


### PR DESCRIPTION
Reconfigures `shogun_align` to use `bowtie2` as its aligner (and catches an uncaught error for HTTP checks).

Note: `shogun_filter` still uses BURST since there's no easy way to configure the aligner for `shogun_filter` from the command line.