### PR TITLE
fix: absolutize output paths, support for ~ paths

### DIFF
--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -18,8 +18,8 @@ def test_async_execution():
 
     test_dir = "test_async_execution"
     os.makedirs(f"./{test_dir}", exist_ok=True)
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}kraken2_output.txt"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/kraken2_output.txt"
 
     custom_db = "s3://toolchest-fsx-databases/kraken2/k2_viral_20210517/"
     toolchest_run = toolchest.kraken2(

--- a/tests/test_chaining.py
+++ b/tests/test_chaining.py
@@ -28,8 +28,8 @@ def test_shi7_shogun_chaining():
 
     test_dir = "test_shi7_shogun_chaining"
     os.makedirs(f"./{test_dir}", exist_ok=True)
-    output_dir_path = f"./{test_dir}/"
-    output_file_path_shogun = f"{output_dir_path}alignment.bowtie2.sam"
+    output_dir_path = f"./{test_dir}"
+    output_file_path_shogun = f"{output_dir_path}/alignment.bowtie2.sam"
 
     output_shi7 = toolchest.shi7(
         tool_args="-SE",

--- a/tests/test_clustalo.py
+++ b/tests/test_clustalo.py
@@ -16,8 +16,8 @@ def test_clustalo_standard():
     """
     test_dir = "test_clustalo_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}sample_output.fasta"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/sample_output.fasta"
 
     toolchest.clustalo(
         inputs="s3://toolchest-integration-tests/clustalo_input.fasta",

--- a/tests/test_diamond.py
+++ b/tests/test_diamond.py
@@ -19,8 +19,8 @@ def test_diamond_blastp_standard():
     """
     test_dir = "test_diamond_blastp_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}sample_output.tsv"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/sample_output.tsv"
 
     toolchest.diamond_blastp(
         inputs="s3://toolchest-integration-tests/diamond_blastp_input.fa",
@@ -37,8 +37,8 @@ def test_diamond_blastx_standard():
     """
     test_dir = "test_diamond_blastx_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}sample_output.tsv"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/sample_output.tsv"
 
     toolchest.diamond_blastx(
         inputs="s3://toolchest-integration-tests/sample_r1_shortened.fastq",

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -19,12 +19,12 @@ def test_kraken2_output_manual_download():
     """
     test_dir = "test_kraken2_output_manual_download"
     input_file_s3_uri = "s3://toolchest-integration-tests/synthetic_bacteroides_reads.fasta"
-    manual_output_dir_path = f"./{test_dir}/manual/"
-    manual_output_file_path = f"{manual_output_dir_path}kraken2_output.txt"
-    toolchest_s3_dir_path = f"./{test_dir}/toolchest/s3/"
-    toolchest_s3_file_path = f"{toolchest_s3_dir_path}kraken2_output.txt"
-    toolchest_pipeline_dir_path = f"./{test_dir}/toolchest/id/"
-    toolchest_pipeline_file_path = f"{toolchest_pipeline_dir_path}kraken2_output.txt"
+    manual_output_dir_path = f"./{test_dir}/manual"
+    manual_output_file_path = f"{manual_output_dir_path}/kraken2_output.txt"
+    toolchest_s3_dir_path = f"./{test_dir}/toolchest/s3"
+    toolchest_s3_file_path = f"{toolchest_s3_dir_path}/kraken2_output.txt"
+    toolchest_pipeline_dir_path = f"./{test_dir}/toolchest/id"
+    toolchest_pipeline_file_path = f"{toolchest_pipeline_dir_path}/kraken2_output.txt"
 
     # Run job without downloading
     output = toolchest.kraken2(

--- a/tests/test_filepath.py
+++ b/tests/test_filepath.py
@@ -1,0 +1,42 @@
+import os
+import pytest
+
+from tests.util import hash, s3
+import toolchest_client as toolchest
+
+toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
+if toolchest_api_key:
+    toolchest.set_key(toolchest_api_key)
+
+
+@pytest.mark.integration
+def test_tilde_filepath():
+    """
+    Tests Kraken 2 against the standard (v1) database
+    """
+    test_dir = "~/test_tilde_filepath"
+    os.makedirs(os.path.expanduser(test_dir), exist_ok=True)
+    input_file_path = "~/kraken_input.fasta"
+    output_dir_path = f"{test_dir}"
+    output_file_path = os.path.expanduser(f"{output_dir_path}/kraken2_output.txt")
+
+    s3.download_integration_test_input(
+        s3_file_key="synthetic_bacteroides_reads.fasta",
+        output_file_path=os.path.expanduser(input_file_path),
+    )
+
+    toolchest_output = toolchest.kraken2(
+        inputs=input_file_path,  # contains tilde
+        output_path=output_dir_path,  # contains tilde
+    )
+
+    assert hash.unordered(output_file_path) == 886254946
+
+    manual_download_dir_path = f"{test_dir}/manual_download"
+    manual_download_file_path = os.path.expanduser(f"{manual_download_dir_path}/kraken2_output.txt")
+    toolchest.download(
+        manual_download_dir_path,  # contains tilde
+        run_id=toolchest_output.run_id
+    )
+
+    assert hash.unordered(manual_download_file_path) == 886254946

--- a/tests/test_filepath.py
+++ b/tests/test_filepath.py
@@ -14,11 +14,10 @@ def test_tilde_filepath():
     """
     Tests Kraken 2 against the standard (v1) database
     """
-    test_dir = "~/test_tilde_filepath"
-    os.makedirs(os.path.expanduser(test_dir), exist_ok=True)
     input_file_path = "~/kraken_input.fasta"
-    output_dir_path = f"{test_dir}"
+    output_dir_path = "~/test_tilde_filepath"
     output_file_path = os.path.expanduser(f"{output_dir_path}/kraken2_output.txt")
+    os.makedirs(os.path.expanduser(output_dir_path), exist_ok=True)
 
     s3.download_integration_test_input(
         s3_file_key="synthetic_bacteroides_reads.fasta",

--- a/tests/test_filepath.py
+++ b/tests/test_filepath.py
@@ -31,7 +31,7 @@ def test_tilde_filepath():
 
     assert hash.unordered(output_file_path) == 886254946
 
-    manual_download_dir_path = f"{test_dir}/manual_download"
+    manual_download_dir_path = f"{output_dir_path}/manual_download"
     manual_download_file_path = os.path.expanduser(f"{manual_download_dir_path}/kraken2_output.txt")
     toolchest.download(
         manual_download_dir_path,  # contains tilde

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -16,8 +16,8 @@ def test_http_input():
     test_dir = "test_http"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_path = "https://toolchest-public-examples-no-encryption.s3.amazonaws.com/example.fastq"
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}test_output.txt"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/test_output.txt"
 
     toolchest.test(
         inputs=input_file_path,

--- a/tests/test_kraken2.py
+++ b/tests/test_kraken2.py
@@ -19,8 +19,8 @@ def test_kraken2_standard():
     test_dir = "test_kraken2_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_path = "./kraken_input.fasta"
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}kraken2_output.txt"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/kraken2_output.txt"
 
     s3.download_integration_test_input(
         s3_file_key="synthetic_bacteroides_reads.fasta",
@@ -44,8 +44,8 @@ def test_kraken2_paired_end():
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_one_file_path = f"./{test_dir}/kraken_input_read1.fastq.gz"
     input_two_file_path = f"./{test_dir}/kraken_input_read2.fastq.gz"
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}kraken2_output.txt"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/kraken2_output.txt"
 
     s3.download_integration_test_input(
         s3_file_key="sample_r1.fastq.gz",
@@ -73,8 +73,8 @@ def test_kraken2_s3():
     """
     test_dir = "test_kraken2_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}kraken2_output.txt"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/kraken2_output.txt"
 
     toolchest.kraken2(
         inputs="s3://toolchest-integration-tests/synthetic_bacteroides_reads.fasta",
@@ -93,8 +93,8 @@ def test_kraken2_custom_db():
 
     test_dir = "test_kraken2_custom_db"
     os.makedirs(f"./{test_dir}", exist_ok=True)
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}kraken2_output.txt"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/kraken2_output.txt"
 
     custom_db = "s3://toolchest-fsx-databases/kraken2/k2_viral_20210517/"
     toolchest.kraken2(

--- a/tests/test_megahit.py
+++ b/tests/test_megahit.py
@@ -23,8 +23,8 @@ def test_megahit_many_types():
     """
     test_dir = "test_megahit_many_types"
     os.makedirs(f"./{test_dir}", exist_ok=True)
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}final.contigs.fa"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/final.contigs.fa"
 
     toolchest.megahit(
         interleaved=[
@@ -55,8 +55,8 @@ def test_megahit_multiple_pairs():
     """
     test_dir = "test_megahit_two_pairs"
     os.makedirs(f"./{test_dir}", exist_ok=True)
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}final.contigs.fa"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/final.contigs.fa"
 
     toolchest.megahit(
         read_one=[

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -17,8 +17,8 @@ def test_star_grch38():
     test_dir = "test_star_grch38"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_path = "./small_star.fastq"
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}Aligned.out.sam"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/Aligned.out.sam"
 
     s3.download_integration_test_input(
         s3_file_key="small_star_500k.fastq",
@@ -45,8 +45,8 @@ def test_star_grch38_parallel():
     test_dir = "test_star_grch38_parallel"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_path = "./large_star.fastq"
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}Aligned.out.sam"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/Aligned.out.sam"
 
     s3.download_integration_test_input(
         s3_file_key="large_star_15GB.fastq",
@@ -73,8 +73,8 @@ def test_star_grch38_dangerous_arg():
     test_dir = "test_star_grch38"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_path = "./small_star.fastq"
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}Aligned.out.bam"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/Aligned.out.bam"
 
     s3.download_integration_test_input(
         s3_file_key="small_star_500k.fastq",

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -69,7 +69,7 @@ def download(output_path, s3_uri=None, pipeline_segment_instance_id=None, run_id
     # Note: Assumes that output_path is a directory if it does not exist.
     # This may lead to undesired leaf dir creation if output_path is not intended to be a dir,
     # but support for non-dir output_path will likely be deprecated.
-    output_path = os.path.abspath(output_path)
+    output_path = os.path.abspath(os.path.expanduser(output_path))
     if not os.path.exists(output_path) and output_type is None:
         if "." in os.path.basename(output_path):
             logging.warning(f"Creating {os.path.basename(output_path)} as a directory along path {output_path}")

--- a/toolchest_client/files/general.py
+++ b/toolchest_client/files/general.py
@@ -5,8 +5,8 @@ toolchest_client.files.general
 General file handling functions.
 """
 
-import shutil
 import os
+import shutil
 
 from .http import get_url_with_protocol, path_is_http_url, get_http_url_file_size
 from .s3 import assert_accessible_s3, get_s3_file_size, path_is_s3_uri
@@ -79,6 +79,9 @@ def files_in_path(files):
     # If it's an HTTP or HTTPS URL, treat it as a file
     if path_is_http_url(files):
         return [get_url_with_protocol(files)]
+
+    # Path is local, expand ~ in path if present
+    files = os.path.expanduser(files)
 
     # If it's a path to something that doesn't exist, error
     assert_exists(files, must_be_file=False)

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -89,11 +89,11 @@ class Tool:
                 self.input_files = [self.inputs]
             else:
                 # Input files are all .tar.gz'd together, preserving directory structure
-                self.input_files = [compress_files_in_path(self.inputs)]
+                self.input_files = [compress_files_in_path(os.path.expanduser(self.inputs))]
             self.num_input_files = 1
         else:
             # Input files are handled individually, destroying directory structure
-            self.input_files = files_in_path(self.inputs)
+            self.input_files = files_in_path(self.inputs)  # expands ~ in filepath if local
             self.num_input_files = len(self.input_files)
 
         if self.num_input_files < self.min_inputs:

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -45,7 +45,8 @@ class Tool:
         self.output_primary_name = output_primary_name
         self.output_path = output_path
         if self._output_path_is_local():
-            self.output_path = output_path
+            # absolutize path, expand user tilde if present
+            self.output_path = os.path.abspath(os.path.expanduser(output_path))
         self.output_is_directory = output_is_directory
         self.inputs = inputs
         # input_prefix_mapping is a dict in the shape of:
@@ -199,8 +200,6 @@ class Tool:
 
         if self.inputs is None:
             raise ValueError("No input provided.")
-        if self._output_path_is_local() and self.output_path.startswith("~"):
-            raise OSError("Output file path must be an absolute path.")
         if not self.output_name:
             raise ValueError("Output name must be non-empty.")
 
@@ -248,7 +247,6 @@ class Tool:
                         output_file_path = f"{self.output_path}/{output_name}"
                         sanity_check(output_file_path)
                 else:
-                    # TODO: verify that this works with absolute pathing
                     for output_name in self.output_names:
                         output_file_path = f"{os.path.dirname(self.output_path)}/{output_name}"
                         sanity_check(output_file_path)


### PR DESCRIPTION
Adds:
- Support for paths that contain `~`.
- Integration tests (using kraken2) for `~` filepaths.
- Absolutizing output paths (for consistency).

Modifies:
- Integration test pathing (to be compatible with absolutized output paths).