### PR TITLE
fix: STAR test pathing, testing config changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
   integration-tests:
     executor: python/default
     working_directory: ~/repo
-    parallelism: 2
+    parallelism: 4
     steps:
       - checkout
       - run:
@@ -58,7 +58,7 @@ jobs:
             shopt -u globstar
             poetry install
             mkdir -p test-results
-            poetry run pytest -v -m integration --junitxml=test-results/junit.xml $TESTFILES
+            poetry run pytest -v -m integration --durations=0 --junitxml=test-results/junit.xml $TESTFILES
           no_output_timeout: 1h
       - store_test_results:
           path: test-results

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -104,7 +104,7 @@ def test_star_grch38_dangerous_arg():
     assert 38236000 <= os.path.getsize(output_file_path) <= 38236100  # expected size 38236044
 
     # Make sure all non-parallel files exist as well
-    assert os.path.isfile(f"{output_dir_path}Log.final.out")
-    assert os.path.isfile(f"{output_dir_path}Log.out")
-    assert os.path.isfile(f"{output_dir_path}Log.progress.out")
-    assert os.path.isfile(f"{output_dir_path}SJ.out.tab")
+    assert os.path.isfile(f"{output_dir_path}/Log.final.out")
+    assert os.path.isfile(f"{output_dir_path}/Log.out")
+    assert os.path.isfile(f"{output_dir_path}/Log.progress.out")
+    assert os.path.isfile(f"{output_dir_path}/SJ.out.tab")


### PR DESCRIPTION
Modifies:
* Pathing for dangerous arg STAR test, in line with paths from #144.
* CircleCI config:
  * Increases number of parallel testing runs from 2 to 4
  * Adds printed test duration to CircleCI stdout