### PR TITLE
feat: custom API URL support

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,4 +8,4 @@ def pytest_configure(config):
     file after command line options have been parsed.
     """
     if os.environ.get("DEPLOY_ENVIRONMENT") == "staging":
-        os.environ["API_URL"] = os.environ["TOOLCHEST_STAGING_URL"]
+        os.environ["TOOLCHEST_API_URL"] = os.environ["TOOLCHEST_STAGING_URL"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,4 +8,4 @@ def pytest_configure(config):
     file after command line options have been parsed.
     """
     if os.environ.get("DEPLOY_ENVIRONMENT") == "staging":
-        os.environ["BASE_URL"] = os.environ["TOOLCHEST_STAGING_URL"]
+        os.environ["API_URL"] = os.environ["TOOLCHEST_STAGING_URL"]

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -29,6 +29,7 @@ from toolchest_client.api.exceptions import ToolchestException, DataLimitError, 
     ToolchestDownloadError
 from toolchest_client.api.query import Query
 from toolchest_client.api.status import Status, get_status
+from toolchest_client.api.urls import get_api_url, set_api_url
 from .tools.api import alphafold, bowtie2, cellranger_count, clustalo, diamond_blastp, diamond_blastx, demucs, kraken2,\
     megahit, rapsearch, rapsearch2, shi7, shogun_align, shogun_filter, STAR, test, unicycler
 

--- a/toolchest_client/api/auth.py
+++ b/toolchest_client/api/auth.py
@@ -13,7 +13,7 @@ import requests
 from requests.exceptions import HTTPError
 
 from toolchest_client.api.exceptions import ToolchestKeyError
-from toolchest_client.api.urls import API_URL
+from toolchest_client.api.urls import get_api_url
 
 
 def get_key():
@@ -53,7 +53,7 @@ def validate_key():
     """Validates Toolchest API key, retrieved from get_key()."""
 
     validation_response = requests.get(
-        API_URL,
+        get_api_url(),
         headers=get_headers(),
     )
     try:

--- a/toolchest_client/api/auth.py
+++ b/toolchest_client/api/auth.py
@@ -13,7 +13,7 @@ import requests
 from requests.exceptions import HTTPError
 
 from toolchest_client.api.exceptions import ToolchestKeyError
-from toolchest_client.api.urls import BASE_URL
+from toolchest_client.api.urls import API_URL
 
 
 def get_key():
@@ -53,7 +53,7 @@ def validate_key():
     """Validates Toolchest API key, retrieved from get_key()."""
 
     validation_response = requests.get(
-        BASE_URL,
+        API_URL,
         headers=get_headers(),
     )
     try:

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -19,7 +19,7 @@ from requests.exceptions import HTTPError
 
 from toolchest_client.api.auth import get_headers
 from toolchest_client.api.exceptions import ToolchestDownloadError
-from toolchest_client.api.urls import PIPELINE_SEGMENT_INSTANCES_URL
+from toolchest_client.api.urls import get_pipeline_segment_instances_url
 from toolchest_client.files import get_file_type, get_params_from_s3_uri, unpack_files
 
 
@@ -107,7 +107,7 @@ def get_download_details(pipeline_segment_instance_id):
     """Gets S3 URI and access keys for downloading output of query task(s)."""
 
     response = requests.get(
-        "/".join([PIPELINE_SEGMENT_INSTANCES_URL, pipeline_segment_instance_id, "downloads"]),
+        "/".join([get_pipeline_segment_instances_url(), pipeline_segment_instance_id, "downloads"]),
         headers=get_headers(),
     )
     try:

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -19,7 +19,7 @@ from toolchest_client.api.auth import get_headers
 from toolchest_client.api.download import download, get_download_details
 from toolchest_client.api.exceptions import ToolchestJobError, ToolchestException, ToolchestDownloadError
 from toolchest_client.api.output import Output
-from toolchest_client.api.urls import PIPELINE_SEGMENT_INSTANCES_URL
+from toolchest_client.api.urls import get_pipeline_segment_instances_url
 from toolchest_client.files import OutputType, path_is_s3_uri, path_is_http_url
 from .status import Status, ThreadStatus
 
@@ -42,7 +42,7 @@ class Query:
         if pipeline_segment_instance_id:
             self.PIPELINE_SEGMENT_INSTANCE_ID = pipeline_segment_instance_id
             self.PIPELINE_SEGMENT_INSTANCE_URL = "/".join([
-                PIPELINE_SEGMENT_INSTANCES_URL,
+                get_pipeline_segment_instances_url(),
                 self.PIPELINE_SEGMENT_INSTANCE_ID,
             ])
             self.STATUS_URL = "/".join([
@@ -106,7 +106,7 @@ class Query:
 
         self.PIPELINE_SEGMENT_INSTANCE_ID = create_content["id"]
         self.PIPELINE_SEGMENT_INSTANCE_URL = "/".join([
-            PIPELINE_SEGMENT_INSTANCES_URL,
+            get_pipeline_segment_instances_url(),
             self.PIPELINE_SEGMENT_INSTANCE_ID
         ])
         self.STATUS_URL = "/".join([
@@ -162,7 +162,7 @@ class Query:
         }
 
         create_response = requests.post(
-            PIPELINE_SEGMENT_INSTANCES_URL,
+            get_pipeline_segment_instances_url(),
             headers=self.HEADERS,
             json=create_body,
         )
@@ -176,7 +176,7 @@ class Query:
 
     def _update_file_size(self, file_id):
         update_file_size_url = "/".join([
-            PIPELINE_SEGMENT_INSTANCES_URL,
+            get_pipeline_segment_instances_url(),
             'input-files',
             file_id,
             'update-file-size'

--- a/toolchest_client/api/urls.py
+++ b/toolchest_client/api/urls.py
@@ -9,11 +9,11 @@ Toolchest queries and API calls.
 import os
 
 # Base URLs used by the server API.
-BASE_URL = os.environ.get("BASE_URL", "https://api.toolche.st")
+API_URL = os.environ.get("API_URL", "https://api.toolche.st")
 
 PIPELINE_SEGMENT_INSTANCES_ROUTE = "/pipeline-segment-instances"
-PIPELINE_SEGMENT_INSTANCES_URL = BASE_URL + PIPELINE_SEGMENT_INSTANCES_ROUTE
+PIPELINE_SEGMENT_INSTANCES_URL = API_URL + PIPELINE_SEGMENT_INSTANCES_ROUTE
 
 S3_ROUTE = "/s3"
-S3_URL = BASE_URL + S3_ROUTE
+S3_URL = API_URL + S3_ROUTE
 S3_METADATA_URL = S3_URL + "/metadata"

--- a/toolchest_client/api/urls.py
+++ b/toolchest_client/api/urls.py
@@ -8,12 +8,41 @@ Toolchest queries and API calls.
 
 import os
 
-# Base URLs used by the server API.
-API_URL = os.environ.get("API_URL", "https://api.toolche.st")
 
-PIPELINE_SEGMENT_INSTANCES_ROUTE = "/pipeline-segment-instances"
-PIPELINE_SEGMENT_INSTANCES_URL = API_URL + PIPELINE_SEGMENT_INSTANCES_ROUTE
+def get_api_url():
+    """Retrieves the base URL for the Toolchest server API. Defaults to "https://api.toolche.st"
+    if a custom API URL is not set.
+    """
+    # Note: BASE_URL is checked for backwards compatibility.
+    return os.environ.get("TOOLCHEST_API_URL", os.environ.get("BASE_URL", "https://api.toolche.st"))
 
-S3_ROUTE = "/s3"
-S3_URL = API_URL + S3_ROUTE
-S3_METADATA_URL = S3_URL + "/metadata"
+
+def get_pipeline_segment_instances_url():
+    """Retrieves the Toolchest API Route for pipeline segment instances. Used internally."""
+    PIPELINE_SEGMENT_INSTANCES_ROUTE = "/pipeline-segment-instances"
+    return get_api_url() + PIPELINE_SEGMENT_INSTANCES_ROUTE
+
+
+def get_s3_metadata_url():
+    """Retrieves the Toolchest API Route for S3 metadata. Used internally."""
+    S3_ROUTE = "/s3"
+    S3_URL = get_api_url() + S3_ROUTE
+    return S3_URL + "/metadata"
+
+
+def set_api_url(custom_api_url=None):
+    """Sets the Toolchest API URL (env var TOOLCHEST_API_URL) to the given value.
+    If a URL is not provided, resets to the default Toolchest API URL.
+
+    :param custom_api_url: Custom API URL. Any trailing slashes should be removed.
+
+    Usage::
+
+        >>> import toolchest_client as toolchest
+        >>> toolchest.set_api_url("http://your.custom.api.url.here")
+
+    """
+    if custom_api_url:
+        os.environ["TOOLCHEST_API_URL"] = custom_api_url
+    else:
+        os.environ.pop("TOOLCHEST_API_URL", None)

--- a/toolchest_client/files/s3.py
+++ b/toolchest_client/files/s3.py
@@ -11,7 +11,7 @@ from requests.exceptions import HTTPError
 
 from toolchest_client.api.auth import get_headers
 from toolchest_client.api.exceptions import ToolchestS3AccessError
-from toolchest_client.api.urls import S3_METADATA_URL
+from toolchest_client.api.urls import get_s3_metadata_url
 
 
 def assert_accessible_s3(uri):
@@ -33,7 +33,7 @@ def get_s3_file_size(uri):
     """
     params = get_params_from_s3_uri(uri)
     response = requests.post(
-        S3_METADATA_URL,
+        get_s3_metadata_url(),
         headers=get_headers(),
         json=params,
     )


### PR DESCRIPTION
Adds:
* Support for custom API URLs, via `toolchest.get_api_url()` and `toolchest.set_api_url()`. Custom API URLs can be set through the `TOOLCHEST_API_URL` environment variable.

Modifies:
* URL handling throughout the package. Instead of global variables stored in `api/urls.py`, every URL is now retrieved through an encapsulated function.