### PR TITLE
fix: bowtie2 integration test input file

### DIFF
--- a/tests/test_bowtie2.py
+++ b/tests/test_bowtie2.py
@@ -24,4 +24,4 @@ def test_bowtie2():
     )
 
     # Bowtie2 hash is non-deterministic but size is consistent between runs
-    assert os.path.getsize(f"{output_dir_path}bowtie2_output.sam") == 739943628
+    assert os.path.getsize(f"{output_dir_path}bowtie2_output.sam") == 1043855350


### PR DESCRIPTION
Now the test uses a human reads file and aligns `89.53%` of the reads instead of `0.01%`.