### PR TITLE
fix: remove run id comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ toolchest.kraken2(
 )
 ```
 
-For a list of available tools, see the [documentation](https://docs.trytoolchest.com/).
+For a list of available tools, see the [documentation](https://docs.trytoolchest.com/docs#-tools).
 
 ## Configuration
 

--- a/toolchest_client/api/output.py
+++ b/toolchest_client/api/output.py
@@ -25,7 +25,7 @@ class Output:
     def __init__(self, s3_uri=None, output_path=None, run_id=None):
         self.s3_uri = s3_uri
         self.output_path = output_path
-        self.run_id = run_id,
+        self.run_id = run_id
 
     def __repr__(self):
         return str(self.__dict__)


### PR DESCRIPTION
Removes typo in `run_id` instantiation in `output.py`.