### PR TITLE
fix: rename output_dir to output_path for consistency

### DIFF
--- a/toolchest_client/api/output.py
+++ b/toolchest_client/api/output.py
@@ -42,9 +42,9 @@ class Output:
     def set_output_path(self, output_path):
         self.output_path = output_path
 
-    def download(self, output_dir, skip_decompression=False):
+    def download(self, output_path, skip_decompression=False):
         self.output_path = download(
-            output_path=output_dir,
+            output_path=output_path,
             s3_uri=self.s3_uri,
             run_id=self.run_id,
             skip_decompression=skip_decompression,


### PR DESCRIPTION
All other path params are called `output_path` so this makes the output download function consistent with the tools and regular download function. 