### PR TITLE
feat: adds a sentry tag to skip paging and notifying slack

### DIFF
--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -13,6 +13,7 @@ import time
 
 import boto3
 import requests
+import sentry_sdk
 from requests.exceptions import HTTPError
 
 from toolchest_client.api.auth import get_headers
@@ -395,6 +396,7 @@ class Query:
         """Checks for flag set by parent process to see if it should terminate self."""
         thread_status = self.thread_statuses.get(self.thread_name)
         if thread_status == ThreadStatus.INTERRUPTING:
+            sentry_sdk.set_tag('send_page', False)
             self._update_status_to_failed(
                 error_message="Terminating due to failure in sibling thread or parent process",
                 force_raise=False,

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -14,6 +14,8 @@ import sys
 from threading import Thread
 import time
 
+import sentry_sdk
+
 from toolchest_client.api.auth import validate_key
 from toolchest_client.api.exceptions import ToolchestException
 from toolchest_client.api.output import Output
@@ -295,6 +297,7 @@ class Tool:
         if self.terminating:
             raise InterruptedError("Toolchest client force killed")
         self.terminating = True
+        sentry_sdk.set_tag('send_page', False)
         self._kill_query_threads()
         raise InterruptedError(f"Toolchest client interrupted by signal #{signal_number}")
 


### PR DESCRIPTION
Only stops paging for thread interrupt errors for now but sets up the tag and alert rules in sentry.