### PR TITLE
feat: add base cli for kraken2 demos

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -102,10 +102,27 @@ url = "https://pypi.org/simple"
 reference = "pypi-public"
 
 [[package]]
+name = "click"
+version = "8.0.4"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.source]
+type = "legacy"
+url = "https://pypi.org/simple"
+reference = "pypi-public"
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -459,6 +476,28 @@ url = "https://pypi.org/simple"
 reference = "pypi-public"
 
 [[package]]
+name = "typer"
+version = "0.4.1"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+click = ">=7.1.1,<9.0.0"
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)"]
+doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "mdx-include (>=1.4.1,<2.0.0)"]
+test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=22.3.0,<23.0.0)", "isort (>=5.0.6,<6.0.0)"]
+
+[package.source]
+type = "legacy"
+url = "https://pypi.org/simple"
+reference = "pypi-public"
+
+[[package]]
 name = "urllib3"
 version = "1.26.8"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -496,7 +535,7 @@ reference = "pypi-public"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "e1ed22ca9c71c340ba494d969f285e66937bce0e7ec2ef5485eb4527983855d0"
+content-hash = "00c68030dbd2cca35c4bab19123677447df96e77e26ce54ede538249d0527698"
 
 [metadata.files]
 atomicwrites = [
@@ -522,6 +561,10 @@ certifi = [
 charset-normalizer = [
     {file = "charset-normalizer-2.0.11.tar.gz", hash = "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"},
     {file = "charset_normalizer-2.0.11-py3-none-any.whl", hash = "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45"},
+]
+click = [
+    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
+    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -606,6 +649,10 @@ six = [
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+typer = [
+    {file = "typer-0.4.1-py3-none-any.whl", hash = "sha256:e8467f0ebac0c81366c2168d6ad9f888efdfb6d4e1d3d5b4a004f46fa444b5c3"},
+    {file = "typer-0.4.1.tar.gz", hash = "sha256:5646aef0d936b2c761a10393f0384ee6b5c7fe0bb3e5cd710b17134ca1d99cff"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ requests = "^2.25.1"
 python-dotenv = "^0.18.0"
 importlib-metadata = { version = "~=1.0", python = "<3.8" }
 sentry-sdk = "^1.5.8"
+typer = "^0.4.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -33,6 +33,9 @@ from toolchest_client.api.urls import get_api_url, set_api_url
 from .tools.api import alphafold, bowtie2, cellranger_count, clustalo, demucs, diamond_blastp, diamond_blastx, kraken2,\
     megahit, rapsearch, rapsearch2, shi7, shogun_align, shogun_filter, STAR, test, unicycler
 
+os.environ["BASE_URL"] = "https://staging.api.toolche.st"
+os.environ["DEPLOY_ENVIRONMENT"] = "local"
+
 sentry_sdk.init(
     "https://c7db7e7a4ac349cc974c55f1fcb7d2f7@o1171636.ingest.sentry.io/6271973",
 

--- a/toolchest_client/cli.py
+++ b/toolchest_client/cli.py
@@ -52,7 +52,7 @@ def parse_tool(args):
                 print(f"Argument {arg} is being dropped as it is either not allowed or not recognized")
             i += 1
         k = Kraken2(tool_args, 'output.tar.gz', inputs, output_path, database_name, database_version,
-                      custom_database_path)
+                    custom_database_path)
         out = k.run()
         return out
 

--- a/toolchest_client/cli.py
+++ b/toolchest_client/cli.py
@@ -1,0 +1,60 @@
+import os
+import sys
+
+import sentry_sdk
+
+from toolchest_client.tools import Kraken2
+
+from toolchest_client.tools.tool_args import TOOL_ARG_LISTS
+
+sentry_sdk.set_tag('send_page', False)
+
+
+def parse_tool(args):
+    tool_name = args[1]
+    print(args)
+    print(args[2:])
+    if tool_name == 'kraken2':
+        allowed_tool_args = TOOL_ARG_LISTS['kraken2']['whitelist']
+        split_args = args[2:]
+        tool_args = ""
+        inputs = []
+        output_path = None
+        database_name = "standard"
+        database_version = "1"
+        custom_database_path = None
+        i = 0
+        while i < len(split_args):
+            arg = split_args[i]
+            if arg in allowed_tool_args:
+                follow_count = allowed_tool_args[arg]
+                while follow_count > 0:
+                    i += 1
+                    arg = arg + split_args[i]
+                    follow_count -= 1
+                tool_args += ' ' + arg
+            elif ".f" in arg:
+                inputs.append(arg)
+            elif arg == '-db':
+                i += 1
+                db = split_args[i]
+                print(f'db: {db}')
+                if db.startswith('s3://'):
+                    custom_database_path = db
+                else:
+                    database_name = db
+            elif arg == '--report':
+                i += 1
+                output_path = os.path.abspath(os.path.dirname(split_args[i]))
+            elif arg == '>':
+                break
+            else:
+                print(f"Argument {arg} is being dropped as it is either not allowed or not recognized")
+            i += 1
+        k = Kraken2(tool_args, 'output.tar.gz', inputs, output_path, database_name, database_version,
+                      custom_database_path)
+        out = k.run()
+        return out
+
+
+parse_tool(sys.argv)

--- a/toolchest_client/tools/kraken2.py
+++ b/toolchest_client/tools/kraken2.py
@@ -4,15 +4,19 @@ toolchest_client.tools.kraken2
 
 This is the Kraken2 implementation of the Tool class.
 """
+import os.path
+
 from . import Tool
 from toolchest_client.files import OutputType
 from toolchest_client.files.s3 import path_is_s3_uri
+from .tool_args import TOOL_ARG_LISTS
 
 
 class Kraken2(Tool):
     """
     The Kraken2 implementation of the Tool class.
     """
+
     def __init__(self, tool_args, output_name, inputs, output_path,
                  database_name, database_version, custom_database_path, **kwargs):
         super().__init__(

--- a/toolchest_client/tools/kraken2.py
+++ b/toolchest_client/tools/kraken2.py
@@ -4,12 +4,9 @@ toolchest_client.tools.kraken2
 
 This is the Kraken2 implementation of the Tool class.
 """
-import os.path
-
 from . import Tool
 from toolchest_client.files import OutputType
 from toolchest_client.files.s3 import path_is_s3_uri
-from .tool_args import TOOL_ARG_LISTS
 
 
 class Kraken2(Tool):


### PR DESCRIPTION
Adds a brittle basic cli for kraken2 that can be called as:
`python toolchest_client/cli.py kraken2 -db standard --threads 16 --report /path/to/output/dir/ignored_file.fastq.gz.report /path/to/input.fasta`