### PR TITLE
fix: standardize output path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ workflows:
               only:
                 - main
                 - staging
+                - fix/standardize-output-path
   deploy:
     jobs:
       - deploy-to-pypi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,6 @@ workflows:
               only:
                 - main
                 - staging
-                - fix/standardize-output-path
   deploy:
     jobs:
       - deploy-to-pypi:

--- a/tests/test_clustalo.py
+++ b/tests/test_clustalo.py
@@ -17,11 +17,13 @@ def test_clustalo_standard():
     test_dir = "test_clustalo_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
-    output_file_path = f"{output_dir_path}/sample_output.fasta"
+    output_file_name = "sample_output.fasta"
+    output_file_path = f"{output_dir_path}/{output_file_name}"
 
     toolchest.clustalo(
         inputs="s3://toolchest-integration-tests/clustalo_input.fasta",
-        output_path=output_file_path,
+        output_path=output_dir_path,
+        output_primary_name=output_file_name,
     )
 
     assert hash.unordered(output_file_path) == 1217555147

--- a/tests/test_diamond.py
+++ b/tests/test_diamond.py
@@ -20,11 +20,13 @@ def test_diamond_blastp_standard():
     test_dir = "test_diamond_blastp_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
-    output_file_path = f"{output_dir_path}/sample_output.tsv"
+    output_file_name = "sample_output.tsv"
+    output_file_path = f"{output_dir_path}/{output_file_name}"
 
     toolchest.diamond_blastp(
         inputs="s3://toolchest-integration-tests/diamond_blastp_input.fa",
-        output_path=output_file_path,
+        output_path=output_dir_path,
+        output_primary_name=output_file_name,
     )
 
     assert hash.unordered(output_file_path) == DEFAULT_BLASTP_OUTPUT_HASH
@@ -38,11 +40,13 @@ def test_diamond_blastx_standard():
     test_dir = "test_diamond_blastx_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
-    output_file_path = f"{output_dir_path}/sample_output.tsv"
+    output_file_name = "sample_output.tsv"
+    output_file_path = f"{output_dir_path}/{output_file_name}"
 
     toolchest.diamond_blastx(
         inputs="s3://toolchest-integration-tests/sample_r1_shortened.fastq",
-        output_path=output_file_path,
+        output_path=output_dir_path,
+        output_primary_name=output_file_name,
     )
 
     assert hash.unordered(output_file_path) == DEFAULT_BLASTX_OUTPUT_HASH

--- a/tests/test_rapsearch2.py
+++ b/tests/test_rapsearch2.py
@@ -23,7 +23,8 @@ def test_rapsearch2():
     toolchest.rapsearch2(
         tool_args="-e 1e-9",
         inputs="s3://toolchest-integration-tests/example.fastq",
-        output_path=f"{test_dir}/rapsearch2",
+        output_path=f"{test_dir}/",
+        output_primary_name="rapsearch2",
     )
 
     # m8 output is nondeterministic, so we check file size

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -20,7 +20,7 @@ from requests.exceptions import HTTPError
 from toolchest_client.api.auth import get_headers
 from toolchest_client.api.exceptions import ToolchestDownloadError
 from toolchest_client.api.urls import get_pipeline_segment_instances_url
-from toolchest_client.files import get_file_type, get_params_from_s3_uri, unpack_files
+from toolchest_client.files import get_params_from_s3_uri, unpack_files
 
 
 def download(output_path, s3_uri=None, pipeline_segment_instance_id=None, run_id=None,

--- a/toolchest_client/api/download.py
+++ b/toolchest_client/api/download.py
@@ -32,8 +32,7 @@ def download(output_path, s3_uri=None, pipeline_segment_instance_id=None, run_id
     extract access keys from `s3_uri` or `run_id` via
     `get_download_details()`.
 
-    :param output_path: Output path to which the file(s) will be downloaded.
-        This should be a local directory, but direct filenames are also supported.
+    :param output_path: Path to a directory to which the file(s) will be downloaded.
     :param s3_uri: URI of file contained in S3. This can be passed from
         the parameter `output.s3_uri` from the `output` returned by a previous
         job.
@@ -61,24 +60,16 @@ def download(output_path, s3_uri=None, pipeline_segment_instance_id=None, run_id
             error_message = "Details of files to download were not provided."
             raise ToolchestDownloadError(error_message) from None
 
-    # If the output path is /path/sample.fastq but the run also has tarred log files, we want to unpack at the directory
-    if output_file_keys["primary_name"]:
-        output_path = os.path.dirname(output_path)
-
-    # Create output directories if output_path does not exist.
-    # Note: Assumes that output_path is a directory if it does not exist.
-    # This may lead to undesired leaf dir creation if output_path is not intended to be a dir,
-    # but support for non-dir output_path will likely be deprecated.
+    # Create output directories if directory at output_path does not exist.
     output_path = os.path.abspath(os.path.expanduser(output_path))
     if not os.path.exists(output_path) and output_type is None:
         if "." in os.path.basename(output_path):
             logging.warning(f"Creating {os.path.basename(output_path)} as a directory along path {output_path}")
         os.makedirs(output_path, exist_ok=True)
 
-    # If output_path is a directory, extract the filename from the target download.
-    if os.path.isdir(output_path):
-        file_name = os.path.basename(output_file_keys["object_name"])
-        output_path = "/".join([output_path, file_name])
+    # Extract the output filename from the target download.
+    output_file_name = os.path.basename(output_file_keys["object_name"])
+    output_file_path = "/".join([output_path, output_file_name])
 
     try:
         s3_client = boto3.client(
@@ -90,7 +81,7 @@ def download(output_path, s3_uri=None, pipeline_segment_instance_id=None, run_id
         s3_client.download_file(
             output_file_keys["bucket"],
             output_file_keys["object_name"],
-            output_path,
+            output_file_path,
         )
     except ClientError as err:
         # TODO: output more detailed error message if write error encountered
@@ -98,9 +89,9 @@ def download(output_path, s3_uri=None, pipeline_segment_instance_id=None, run_id
         raise ToolchestDownloadError(error_message) from None
 
     if skip_decompression:
-        return output_path
-    unpacked_output_paths = _unpack_output(output_path, output_file_keys["is_compressed"])
-    return unpacked_output_paths
+        return output_file_path
+    unpacked_output_file_paths = _unpack_output(output_file_path, output_file_keys["is_compressed"])
+    return unpacked_output_file_paths
 
 
 def get_download_details(pipeline_segment_instance_id):
@@ -131,15 +122,15 @@ def get_download_details(pipeline_segment_instance_id):
     return output_s3_uri, output_file_keys
 
 
-def _unpack_output(compressed_output_path, is_compressed):
+def _unpack_output(compressed_output_archive_path, is_compressed):
     """After downloading, unpack files if needed"""
     try:
         unpacked_output_paths = unpack_files(
-            file_path_to_unpack=compressed_output_path,
+            file_path_to_unpack=compressed_output_archive_path,
             is_compressed=is_compressed,
         )
     except Exception as err:
-        error_message = f"Failed to unpack file at {compressed_output_path}."
+        error_message = f"Failed to unpack file at {compressed_output_archive_path}."
         if sys.platform == "win32":
             PATH_TOO_LONG_CODE = 206
             if isinstance(err, FileNotFoundError) and err.winerror == PATH_TOO_LONG_CODE:

--- a/toolchest_client/api/output.py
+++ b/toolchest_client/api/output.py
@@ -45,7 +45,7 @@ class Output:
     def download(self, output_dir=None, output_path=None, skip_decompression=False):
         if not output_path:
             output_path = output_dir  # backwards compatibility for old calls
-            
+
         self.output_path = download(
             output_path=output_path,
             s3_uri=self.s3_uri,

--- a/toolchest_client/api/output.py
+++ b/toolchest_client/api/output.py
@@ -42,9 +42,12 @@ class Output:
     def set_output_path(self, output_path):
         self.output_path = output_path
 
-    def download(self, output_dir, skip_decompression=False):
+    def download(self, output_dir=None, output_path=None, skip_decompression=False):
+        if not output_path:
+            output_path = output_dir  # backwards compatibility for old calls
+            
         self.output_path = download(
-            output_path=output_dir,
+            output_path=output_path,
             s3_uri=self.s3_uri,
             run_id=self.run_id,
             skip_decompression=skip_decompression,

--- a/toolchest_client/api/output.py
+++ b/toolchest_client/api/output.py
@@ -42,8 +42,10 @@ class Output:
     def set_output_path(self, output_path):
         self.output_path = output_path
 
-    def download(self, output_dir=None, output_path=None, skip_decompression=False):
+    def download(self, output_path=None, output_dir=None, skip_decompression=False):
         if not output_path:
+            if not output_dir:
+                raise ValueError("Output destination directory (output_path) must be specified.")
             output_path = output_dir  # backwards compatibility for old calls
 
         self.output_path = download(

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -63,7 +63,7 @@ class Query:
 
     def run_query(self, tool_name, tool_version, input_prefix_mapping,
                   output_type, tool_args=None, database_name=None, database_version=None,
-                  custom_database_path=None, output_name="output", output_primary_name=None,
+                  custom_database_path=None, output_primary_name=None,
                   input_files=None, output_path=None, skip_decompression=False, thread_statuses=None):
         """Executes a query to the Toolchest API.
 
@@ -74,7 +74,6 @@ class Query:
         :param database_version: Version of database to be used.
         :param custom_database_path: Path (S3 URI) to a custom database.
         :param input_prefix_mapping: Mapping of input filepaths to associated prefix tags (e.g., "-1")
-        :param output_name: (optional) Internal name of file outputted by the tool.
         :param output_primary_name: (optional) basename of the primary output (e.g. "sample.fastq").
         :param input_files: List of paths to be passed in as input.
         :param output_path: Path (client-side) where the output file will be downloaded.
@@ -93,7 +92,6 @@ class Query:
             database_name=database_name,
             database_version=database_version,
             custom_database_path=custom_database_path,
-            output_name=output_name,
             output_primary_name=output_primary_name,
             tool_name=tool_name,
             tool_version=tool_version,
@@ -141,8 +139,7 @@ class Query:
 
     def _send_initial_request(self, tool_name, tool_version, tool_args,
                               database_name, database_version, custom_database_path,
-                              output_name, output_primary_name, output_file_path,
-                              compress_output):
+                              output_primary_name, output_file_path, compress_output):
         """Sends the initial request to the Toolchest API to create the query.
 
         Returns the response from the POST request.
@@ -154,7 +151,6 @@ class Query:
             "custom_database_s3_location": custom_database_path,
             "database_name": database_name,
             "database_version": database_version,
-            "output_file_name": output_name,
             "output_file_primary_name": output_primary_name,
             "tool_name": tool_name,
             "tool_version": tool_version,

--- a/toolchest_client/files/__init__.py
+++ b/toolchest_client/files/__init__.py
@@ -2,5 +2,5 @@ from .general import assert_exists, check_file_size, files_in_path, sanity_check
 from .merge import concatenate_files, merge_sam_files
 from .s3 import assert_accessible_s3, get_s3_file_size, get_params_from_s3_uri, path_is_s3_uri
 from .split import open_new_output_file, split_file_by_lines, split_paired_files_by_lines
-from .unpack import OutputType, unpack_files, get_file_type
+from .unpack import OutputType, unpack_files
 from .http import get_url_with_protocol, path_is_http_url, get_http_url_file_size

--- a/toolchest_client/files/unpack.py
+++ b/toolchest_client/files/unpack.py
@@ -11,18 +11,12 @@ class OutputType(Enum):
     S3 = ""
 
 
-def unpack_files(file_path_to_unpack, output_type):
+def unpack_files(file_path_to_unpack, is_compressed):
     """Unpack output file, if needed. Returns the path(s) to the (optionally) unpacked output.
     If only 1 file is unpacked, returns a string containing that file's path.
     If there are multiple unpacked files, returns a list of paths.
     """
-    if output_type == OutputType.FLAT_TEXT:
-        return file_path_to_unpack
-    elif output_type == OutputType.SAM_FILE:
-        return file_path_to_unpack
-    elif output_type == OutputType.S3:
-        return file_path_to_unpack
-    elif output_type == OutputType.GZ_TAR:
+    if is_compressed:
         # Get names of files in archive
         with tarfile.open(file_path_to_unpack) as tar:
             unpacked_file_names = tar.getnames()
@@ -45,18 +39,5 @@ def unpack_files(file_path_to_unpack, output_type):
         if len(unpacked_file_paths) == 1:
             return unpacked_file_paths[0]
         return unpacked_file_paths
-
     else:
-        raise NotImplementedError(f"Output type {output_type} unpacking is not implemented")
-
-
-def get_file_type(file_path):
-    """Gets file type from available types registered in OutputType.
-    Raises an error if the file does not match any registered type.
-
-    TODO: add default handling for plaintext files apart from .txt files
-    """
-    for output_type in OutputType:
-        if file_path.endswith(output_type.value):
-            return output_type
-    raise NotImplementedError(f"Handling of output type for file at {file_path} is not implemented")
+        return file_path_to_unpack

--- a/toolchest_client/tools/alphafold.py
+++ b/toolchest_client/tools/alphafold.py
@@ -25,6 +25,5 @@ class AlphaFold(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_path=output_path,
-            output_is_directory=True,
             **kwargs,
         )

--- a/toolchest_client/tools/alphafold.py
+++ b/toolchest_client/tools/alphafold.py
@@ -17,7 +17,6 @@ class AlphaFold(Tool):
             tool_name="alphafold",
             tool_version="2.1.2",
             tool_args=tool_args,
-            output_name='output.tar.gz',
             inputs=inputs,
             min_inputs=1,
             max_inputs=1,

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -80,7 +80,6 @@ def bowtie2(inputs, output_path=None, database_name="GRCh38_noalt_as", database_
 
     instance = Bowtie2(
         tool_args=tool_args,
-        output_name='output.tar.gz',
         inputs=inputs,
         output_path=output_path,
         database_name=database_name,
@@ -118,7 +117,6 @@ def cellranger_count(inputs, database_name="GRCh38", output_path=None, tool_args
 
     instance = CellRangerCount(
         tool_args=tool_args,
-        output_name='output.tar.gz',
         inputs=inputs,
         output_path=output_path,
         database_name=database_name,
@@ -149,7 +147,6 @@ def clustalo(inputs, output_path=None, tool_args="", **kwargs):
 
     instance = ClustalO(
         tool_args=tool_args,
-        output_name='output.tar.gz',
         inputs=inputs,
         output_path=output_path,
         **kwargs,
@@ -178,7 +175,6 @@ def demucs(inputs, output_path=None, tool_args="", **kwargs):
 
     instance = Demucs(
         tool_args=tool_args,
-        output_name='output.tar.gz',
         inputs=inputs,
         output_path=output_path,
         **kwargs,
@@ -208,7 +204,6 @@ def diamond_blastp(inputs, output_path=None, tool_args="", **kwargs):
       """
     instance = DiamondBlastp(
         inputs=inputs,
-        output_name='output.tar.gz',
         output_path=output_path,
         tool_args=tool_args,
         **kwargs,
@@ -234,7 +229,6 @@ def diamond_blastx(inputs, output_path=None, tool_args="", **kwargs):
       """
     instance = DiamondBlastx(
         inputs=inputs,
-        output_name='output.tar.gz',
         output_path=output_path,
         tool_args=tool_args,
         **kwargs,
@@ -299,7 +293,6 @@ def kraken2(output_path=None, inputs=[], database_name="standard", database_vers
 
     instance = Kraken2(
         tool_args=tool_args,
-        output_name='output.tar.gz',
         inputs=inputs,
         output_path=output_path,
         database_name=database_name,
@@ -364,7 +357,6 @@ def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interl
 
     instance = Megahit(
         tool_args=tool_args,
-        output_name='output.tar.gz',
         input_prefix_mapping=input_prefix_mapping,
         inputs=input_list,
         output_path=output_path,
@@ -395,7 +387,6 @@ def rapsearch2(inputs, output_path=None, database_name="rapsearch2_seqscreen", d
 
     instance = Rapsearch2(
         tool_args=tool_args,
-        output_name='output.tar.gz',
         database_name=database_name,
         database_version=database_version,
         inputs=inputs,
@@ -430,7 +421,6 @@ def shi7(inputs, output_path=None, tool_args="", **kwargs):
 
     instance = Shi7(
         tool_args=tool_args,
-        output_name='output.tar.gz',
         inputs=inputs,
         output_path=output_path,
         **kwargs,
@@ -465,7 +455,6 @@ def shogun_align(inputs, output_path=None, database_name="shogun_standard", data
 
     instance = ShogunAlign(
         tool_args=tool_args,
-        output_name='output.tar.gz',
         inputs=inputs,
         output_path=output_path,
         database_name=database_name,
@@ -502,7 +491,6 @@ def shogun_filter(inputs, output_path=None, database_name="shogun_standard", dat
 
     instance = ShogunFilter(
         tool_args=tool_args,
-        output_name='output.tar.gz',
         inputs=inputs,
         output_path=output_path,
         database_name=database_name,
@@ -546,7 +534,7 @@ def STAR(read_one, database_name="GRCh38", output_path=None, database_version="1
         inputs.append(read_two)
     instance = STARInstance(
         tool_args=tool_args,
-        output_name="Aligned.out.sam" if parallelize else "output.tar.gz",
+        output_primary_name="Aligned.out.sam" if parallelize else None,
         input_prefix_mapping={
             read_one: None,
             read_two: None,
@@ -581,7 +569,6 @@ def test(inputs, output_path=None, tool_args="", **kwargs):
 
     instance = Test(
         tool_args=tool_args,
-        output_name='output.tar.gz',
         inputs=inputs,
         output_path=output_path,
         **kwargs,
@@ -614,7 +601,6 @@ def unicycler(output_path=None, read_one=None, read_two=None, long_reads=None, t
 
     instance = Unicycler(
         tool_args=tool_args,
-        output_name="output.tar.gz",
         input_prefix_mapping={
             read_one: {"prefix": "-1"},
             read_two: {"prefix": "-2"},

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -379,7 +379,7 @@ def rapsearch2(inputs, output_path=None, database_name="rapsearch2_seqscreen", d
     """Runs RAPSearch2 via Toolchest.
     :param inputs: Path to a FASTA/FASTQ file that will be passed in as input.
     :param output_path: (optional) Base path to where the output file(s) will be downloaded.
-    (Functions the same way as the "-o" tag for Rapsearch.)
+    (Functions the same way as the "-o" tag for RAPSearch2.)
     :param tool_args: (optional) Additional arguments to be passed to RAPSearch2.
     :param database_name: (optional) Name of database to use for RAPSearch2 alignment. Defaults to SeqScreen DB.
     :param database_version: (optional) Version of database to use for RAPSearch2 alignment. Defaults to 1.

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -64,7 +64,7 @@ def bowtie2(inputs, output_path=None, database_name="GRCh38_noalt_as", database_
     :param database_version: (optional) Version of database to use for Bowtie 2 alignment.
     :type database_version: str
     :param inputs: Path or list of paths (client-side) to be passed in as input.
-    :param output_path: (optional) Path (client-side) where the output file will be downloaded.
+    :param output_path: (optional) Path to directory where the output file(s) will be downloaded
 
     Usage::
 
@@ -127,11 +127,12 @@ def cellranger_count(inputs, database_name="GRCh38", output_path=None, tool_args
     return output
 
 
-def clustalo(inputs, output_path=None, tool_args="", **kwargs):
+def clustalo(inputs, output_path=None, output_primary_name=None, tool_args="", **kwargs):
     """Runs Clustal Omega via Toolchest.
 
     :param inputs: Path (client-side) to a FASTA file that will be passed in as input.
-    :param output_path: (optional) Path (client-side) where the output file will be downloaded.
+    :param output_path: (optional) Path to directory where the output file(s) will be downloaded.
+    :param output_primary_name: (optional) Base name of output file.
     :param tool_args: Additional arguments to be passed to Clustal Omega.
 
     Usage::
@@ -149,6 +150,7 @@ def clustalo(inputs, output_path=None, tool_args="", **kwargs):
         tool_args=tool_args,
         inputs=inputs,
         output_path=output_path,
+        output_primary_name=output_primary_name,
         **kwargs,
     )
     output = instance.run()
@@ -159,7 +161,7 @@ def demucs(inputs, output_path=None, tool_args="", **kwargs):
     """Runs demucs via Toolchest.
 
     :param inputs: Path to a file that will be passed in as input. All formats supported by ffmpeg are allowed.
-    :param output_path: (optional) Path where the output will be downloaded.
+    :param output_path: (optional) Path to directory where the output file(s) will be downloaded.
     :param tool_args: Additional arguments to be passed to demucs.
 
     Usage::
@@ -183,13 +185,14 @@ def demucs(inputs, output_path=None, tool_args="", **kwargs):
     return output
 
 
-def diamond_blastp(inputs, output_path=None, tool_args="", **kwargs):
+def diamond_blastp(inputs, output_path=None, output_primary_name="out_file.tsv", tool_args="", **kwargs):
     """Runs diamond blastp via Toolchest.
 
       :param inputs: Path to a file that will be passed in as input. FASTA or FASTQ formats are supported (it may be
         gzip compressed)
-      :param output_path: (optional) File path where the output will be downloaded. Log file (diamond.log) will be
-        downloaded in the same directory as the out file
+      :param output_path: (optional) (optional) Path to directory where the output file(s) will be downloaded.
+        Log file (diamond.log) will be downloaded in the same directory as the out file(s).
+      :param output_primary_name: (optional) Base name of output file.
       :param tool_args: Additional arguments to be passed to diamond blastp.
 
       Usage::
@@ -198,13 +201,15 @@ def diamond_blastp(inputs, output_path=None, tool_args="", **kwargs):
           >>> toolchest.diamond_blastp(
           ...     tool_args="",
           ...     inputs="./path/to/input.fa",
-          ...     output_path="./path/to/output/out_file.tsv",
+          ...     output_path="./path/to/output/",
+          ...     output_primary_name="out_file.tsv",
           ... )
 
       """
     instance = DiamondBlastp(
         inputs=inputs,
         output_path=output_path,
+        output_primary_name=output_primary_name,
         tool_args=tool_args,
         **kwargs,
     )
@@ -212,24 +217,29 @@ def diamond_blastp(inputs, output_path=None, tool_args="", **kwargs):
     return output
 
 
-def diamond_blastx(inputs, output_path=None, tool_args="", **kwargs):
+def diamond_blastx(inputs, output_path=None, output_primary_name="out_file.tsv", tool_args="", **kwargs):
     """Runs diamond blastx via Toolchest.
       :param inputs: Path to a file that will be passed in as input. FASTA or FASTQ formats are supported (it may be
         gzip compressed)
-      :param output_path: (optional) File path where the output will be downloaded. Log file (diamond.log) will be
-        downloaded in the same directory as the out file
+      :param output_path: (optional) (optional) Path to directory where the output file(s) will be downloaded.
+        Log file (diamond.log) will be downloaded in the same directory as the out file(s).
+      :param output_primary_name: (optional) Base name of output file.
       :param tool_args: Additional arguments to be passed to diamond blastx.
       Usage::
+
           >>> import toolchest_client as toolchest
-          >>> toolchest.diamond_blastp(
+          >>> toolchest.diamond_blastx(
           ...     tool_args="",
           ...     inputs="./path/to/input.fa",
-          ...     output_path="./path/to/output/out_file.tsv",
+          ...     output_path="./path/to/output/",
+          ...     output_primary_name="out_file.tsv",
           ... )
+
       """
     instance = DiamondBlastx(
         inputs=inputs,
         output_path=output_path,
+        output_primary_name=output_primary_name,
         tool_args=tool_args,
         **kwargs,
     )
@@ -308,7 +318,7 @@ def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interl
             single_end=None, **kwargs):
     """Runs Megahit via Toolchest.
 
-    :param output_path: (optional) Path (client-side) where the output will be downloaded.
+    :param output_path: (optional) Path (client-side) to a directory where the output files will be downloaded.
     :param tool_args: (optional) Additional arguments to be passed to Megahit.
     :param read_one: (optional) `-1` inputs. Path or list of paths for read 1 of paired-read input files.
     :param read_two: (optional) `-2` inputs. Path or list of paths for read 2 of paired-read input files.
@@ -366,12 +376,13 @@ def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interl
     return output
 
 
-def rapsearch2(inputs, output_path=None, database_name="rapsearch2_seqscreen", database_version="1",
-               tool_args="", **kwargs):
+def rapsearch2(inputs, output_path=None, output_primary_name="output", database_name="rapsearch2_seqscreen",
+               database_version="1", tool_args="", **kwargs):
     """Runs RAPSearch2 via Toolchest.
     :param inputs: Path to a FASTA/FASTQ file that will be passed in as input.
-    :param output_path: (optional) Base path to where the output file(s) will be downloaded.
-    (Functions the same way as the "-o" tag for RAPSearch2.)
+    :param output_path: (optional) Path (client-side) to a directory where the output files will be downloaded.
+    :param output_primary_name: (optional) Base name of output file(s).
+    (Functions the same way as the "-o" tag for RAPSearch2, in combination with `output_path`.)
     :param tool_args: (optional) Additional arguments to be passed to RAPSearch2.
     :param database_name: (optional) Name of database to use for RAPSearch2 alignment. Defaults to SeqScreen DB.
     :param database_version: (optional) Version of database to use for RAPSearch2 alignment. Defaults to 1.
@@ -381,7 +392,9 @@ def rapsearch2(inputs, output_path=None, database_name="rapsearch2_seqscreen", d
         >>> toolchest.rapsearch(
         ...     tool_args="",
         ...     inputs="./path/to/input",
-        ...     output_path="./path/to/output/base",  # outputs
+        ...     output_path="./path/to/output/",
+        ...     output_primary_name="base"
+        ...     # full base output path (-o flag) is ./path/to/output/base
         ... )
     """
 
@@ -391,6 +404,7 @@ def rapsearch2(inputs, output_path=None, database_name="rapsearch2_seqscreen", d
         database_version=database_version,
         inputs=inputs,
         output_path=output_path,
+        output_primary_name=output_primary_name,
         **kwargs,
     )
     output = instance.run()
@@ -406,7 +420,7 @@ def shi7(inputs, output_path=None, tool_args="", **kwargs):
 
     :param tool_args: (optional) Additional arguments to be passed to shi7.
     :param inputs: Path or list of paths (client-side) to be passed in as input.
-    :param output_path: (optional) Path (client-side) where the output file will be downloaded.
+    :param output_path: (optional) Path (client-side) to a directory where the output files will be downloaded.
     :return: An Output object, containing info about the output file's location in cloud and/or local storage.
 
     Usage::
@@ -438,7 +452,7 @@ def shogun_align(inputs, output_path=None, database_name="shogun_standard", data
     :param database_version: (optional) Version of database to use for Shogun alignment.
     :type database_version: str
     :param inputs: Path to be passed in as input.
-    :param output_path: (optional) Path (client-side) where the output file will be downloaded.
+    :param output_path: (optional) Path (client-side) to a directory where the output files will be downloaded.
     :return: An Output object, containing info about the output file's location in cloud and/or local storage.
 
     Usage::
@@ -474,7 +488,7 @@ def shogun_filter(inputs, output_path=None, database_name="shogun_standard", dat
     :param database_version: (optional) Version of database to use for Shogun alignment.
     :type database_version: str
     :param inputs: Path to be passed in as input.
-    :param output_path: (optional) Path (client-side) where the output file will be downloaded.
+    :param output_path: (optional) Path (client-side) to a directory where the output files will be downloaded.
     :return: An Output object, containing info about the output file's location in cloud and/or local storage.
 
     Usage::
@@ -511,7 +525,7 @@ def STAR(read_one, database_name="GRCh38", output_path=None, database_version="1
     :param tool_args: (optional) Additional arguments to be passed to STAR.
     :param read_one: Path to the file containing single input file, or R1 short reads for paired-end inputs.
     :param read_two: (optional) Path to the file containing R2 short reads for paired-end inputs.
-    :param output_path: (optional) Path (client-side) where the output file will be downloaded.
+    :param output_path: (optional) Path (client-side) to a directory where the output files will be downloaded.
     :param parallelize: (optional) Allow parallelization of STAR if needed.
 
     .. note:: Single-read inputs should be supplied in the `read_one` argument by themselves.
@@ -555,7 +569,7 @@ def test(inputs, output_path=None, tool_args="", **kwargs):
 
     :param tool_args: Additional arguments, present to maintain a consistent interface. This is disregarded.
     :param inputs: Path or list of paths (client-side) to be passed in as input.
-    :param output_path: (optional) Path (client-side) where the output file will be downloaded.
+    :param output_path: (optional) Path (client-side) to a directory where the output files will be downloaded.
 
     Usage::
 
@@ -584,7 +598,7 @@ def unicycler(output_path=None, read_one=None, read_two=None, long_reads=None, t
     :param read_one: (optional) Path to the file containing R1 short reads.
     :param read_two: (optional) Path to the file containing R2 short reads.
     :param long_reads: (optional) Path to the file containing long reads.
-    :param output_path: (optional) Path (client-side) where the output file will be downloaded.
+    :param output_path: (optional) Path (client-side) to a directory where the output files will be downloaded.
 
     Usage::
 

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -141,7 +141,9 @@ def clustalo(inputs, output_path=None, output_primary_name=None, tool_args="", *
         >>> toolchest.clustalo(
         ...     tool_args="",
         ...     inputs="./path/to/input",
-        ...     output_path="./path/to/output.fasta",
+        ...     output_path="./path/to/output",
+        ...     output_primary_name="output.fasta",
+        ...     # primary output file will be downloaded to ./path/to/output/output.fasta
         ... )
 
     """

--- a/toolchest_client/tools/bowtie2.py
+++ b/toolchest_client/tools/bowtie2.py
@@ -13,13 +13,12 @@ class Bowtie2(Tool):
     """
     The bowtie2 implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, output_path,
-                 database_name, database_version, **kwargs):
+    def __init__(self, tool_args, inputs, output_path, database_name,
+                 database_version, **kwargs):
         super().__init__(
             tool_name="bowtie2",
             tool_version="2.4.4",  # todo: allow bowtie2 version to be set by the user
             tool_args=tool_args,
-            output_name=output_name,
             output_path=output_path,
             inputs=inputs,
             min_inputs=1,
@@ -29,6 +28,6 @@ class Bowtie2(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_is_directory=True,
-            output_names=["bowtie2.log", "bowtie2_output.sam"],
+            expected_output_file_names=["bowtie2.log", "bowtie2_output.sam"],
             **kwargs,
         )

--- a/toolchest_client/tools/bowtie2.py
+++ b/toolchest_client/tools/bowtie2.py
@@ -27,7 +27,6 @@ class Bowtie2(Tool):
             database_version=database_version,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=True,
             expected_output_file_names=["bowtie2.log", "bowtie2_output.sam"],
             **kwargs,
         )

--- a/toolchest_client/tools/cellranger.py
+++ b/toolchest_client/tools/cellranger.py
@@ -27,6 +27,5 @@ class CellRangerCount(Tool):
             compress_inputs=True,
             max_input_bytes_per_file=128 * 1024 * 1024 * 1024,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=True,
             **kwargs,
         )

--- a/toolchest_client/tools/cellranger.py
+++ b/toolchest_client/tools/cellranger.py
@@ -12,13 +12,12 @@ class CellRangerCount(Tool):
     """
     The cellranger_count implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, output_path,
-                 database_name, database_version, **kwargs):
+    def __init__(self, tool_args, inputs, output_path, database_name,
+                 database_version, **kwargs):
         super().__init__(
             tool_name="cellranger_count",
             tool_version="6.1.2",  # todo: allow cellranger version to be set by the user
             tool_args=tool_args,
-            output_name=output_name,
             output_path=output_path,
             inputs=inputs,
             min_inputs=1,

--- a/toolchest_client/tools/clustalo.py
+++ b/toolchest_client/tools/clustalo.py
@@ -24,7 +24,6 @@ class ClustalO(Tool):
             max_inputs=1,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=True,
             expected_output_file_names=[output_primary_name, f"{output_primary_name}.log"],
             **kwargs,
         )

--- a/toolchest_client/tools/clustalo.py
+++ b/toolchest_client/tools/clustalo.py
@@ -4,8 +4,6 @@ toolchest_client.tools.clustalo
 
 This is the Clustal Omega implementation of the Tool class.
 """
-import os
-
 from . import Tool
 from toolchest_client.files import OutputType
 

--- a/toolchest_client/tools/clustalo.py
+++ b/toolchest_client/tools/clustalo.py
@@ -14,13 +14,12 @@ class ClustalO(Tool):
     """
     The Clustal Omega implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, output_path, **kwargs):
+    def __init__(self, tool_args, inputs, output_path, **kwargs):
         output_primary_name = os.path.basename(output_path)
         super().__init__(
             tool_name="clustalo",
             tool_version='1.2.4',
             tool_args=tool_args,
-            output_name=output_name,
             output_primary_name=output_primary_name,
             output_path=output_path,
             inputs=inputs,
@@ -29,6 +28,6 @@ class ClustalO(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_is_directory=False,
-            output_names=[output_primary_name, f"{output_primary_name}.log"],
+            expected_output_file_names=[output_primary_name, f"{output_primary_name}.log"],
             **kwargs,
         )

--- a/toolchest_client/tools/clustalo.py
+++ b/toolchest_client/tools/clustalo.py
@@ -24,7 +24,7 @@ class ClustalO(Tool):
             max_inputs=1,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=False,
+            output_is_directory=True,
             expected_output_file_names=[output_primary_name, f"{output_primary_name}.log"],
             **kwargs,
         )

--- a/toolchest_client/tools/clustalo.py
+++ b/toolchest_client/tools/clustalo.py
@@ -14,8 +14,7 @@ class ClustalO(Tool):
     """
     The Clustal Omega implementation of the Tool class.
     """
-    def __init__(self, tool_args, inputs, output_path, **kwargs):
-        output_primary_name = os.path.basename(output_path)
+    def __init__(self, tool_args, inputs, output_path, output_primary_name, **kwargs):
         super().__init__(
             tool_name="clustalo",
             tool_version='1.2.4',

--- a/toolchest_client/tools/demucs.py
+++ b/toolchest_client/tools/demucs.py
@@ -12,12 +12,11 @@ class Demucs(Tool):
     """
     The Demucs implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, output_path, **kwargs):
+    def __init__(self, tool_args, inputs, output_path, **kwargs):
         super().__init__(
             tool_name="demucs",
             tool_version='3.0.4',
             tool_args=tool_args,
-            output_name=output_name,
             output_path=output_path,
             inputs=inputs,
             min_inputs=1,
@@ -25,6 +24,6 @@ class Demucs(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_is_directory=True,
-            output_names=["error.log", "output.log"],
+            expected_output_file_names=["error.log", "output.log"],
             **kwargs,
         )

--- a/toolchest_client/tools/demucs.py
+++ b/toolchest_client/tools/demucs.py
@@ -23,7 +23,6 @@ class Demucs(Tool):
             max_inputs=1,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=True,
             expected_output_file_names=["error.log", "output.log"],
             **kwargs,
         )

--- a/toolchest_client/tools/diamond.py
+++ b/toolchest_client/tools/diamond.py
@@ -14,13 +14,12 @@ class DiamondBlastp(Tool):
     """
     The Diamond Blastp implementation of the Tool class.
     """
-    def __init__(self, inputs, output_name, output_path, tool_args, **kwargs):
+    def __init__(self, inputs, output_path, tool_args, **kwargs):
         output_primary_name = os.path.basename(output_path)
         super().__init__(
             tool_name="diamond_blastp",
             tool_version="2.0.14",
             tool_args=tool_args,
-            output_name=output_name,
             output_primary_name=output_primary_name,
             inputs=inputs,
             min_inputs=1,
@@ -31,7 +30,7 @@ class DiamondBlastp(Tool):
             output_type=OutputType.GZ_TAR,
             output_path=output_path,
             output_is_directory=False,
-            output_names=[output_primary_name, "diamond.log"],
+            expected_output_file_names=[output_primary_name, "diamond.log"],
             **kwargs,
         )
 
@@ -40,13 +39,12 @@ class DiamondBlastx(Tool):
     """
     The Diamond Blastx implementation of the Tool class.
     """
-    def __init__(self, inputs, output_name, output_path, tool_args, **kwargs):
+    def __init__(self, inputs, output_path, tool_args, **kwargs):
         output_primary_name = os.path.basename(output_path)
         super().__init__(
             tool_name="diamond_blastx",
             tool_version="2.0.13",
             tool_args=tool_args,
-            output_name=output_name,
             output_primary_name=output_primary_name,
             inputs=inputs,
             min_inputs=1,
@@ -57,6 +55,6 @@ class DiamondBlastx(Tool):
             output_type=OutputType.GZ_TAR,
             output_path=output_path,
             output_is_directory=False,
-            output_names=[output_primary_name, "diamond.log"],
+            expected_output_file_names=[output_primary_name, "diamond.log"],
             **kwargs,
         )

--- a/toolchest_client/tools/diamond.py
+++ b/toolchest_client/tools/diamond.py
@@ -14,8 +14,7 @@ class DiamondBlastp(Tool):
     """
     The Diamond Blastp implementation of the Tool class.
     """
-    def __init__(self, inputs, output_path, tool_args, **kwargs):
-        output_primary_name = os.path.basename(output_path)
+    def __init__(self, inputs, output_path, output_primary_name, tool_args, **kwargs):
         super().__init__(
             tool_name="diamond_blastp",
             tool_version="2.0.14",
@@ -39,8 +38,7 @@ class DiamondBlastx(Tool):
     """
     The Diamond Blastx implementation of the Tool class.
     """
-    def __init__(self, inputs, output_path, tool_args, **kwargs):
-        output_primary_name = os.path.basename(output_path)
+    def __init__(self, inputs, output_path, output_primary_name, tool_args, **kwargs):
         super().__init__(
             tool_name="diamond_blastx",
             tool_version="2.0.13",

--- a/toolchest_client/tools/diamond.py
+++ b/toolchest_client/tools/diamond.py
@@ -26,7 +26,6 @@ class DiamondBlastp(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_path=output_path,
-            output_is_directory=True,
             expected_output_file_names=[output_primary_name, "diamond.log"],
             **kwargs,
         )
@@ -50,7 +49,6 @@ class DiamondBlastx(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_path=output_path,
-            output_is_directory=True,
             expected_output_file_names=[output_primary_name, "diamond.log"],
             **kwargs,
         )

--- a/toolchest_client/tools/diamond.py
+++ b/toolchest_client/tools/diamond.py
@@ -26,7 +26,7 @@ class DiamondBlastp(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_path=output_path,
-            output_is_directory=False,
+            output_is_directory=True,
             expected_output_file_names=[output_primary_name, "diamond.log"],
             **kwargs,
         )
@@ -50,7 +50,7 @@ class DiamondBlastx(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_path=output_path,
-            output_is_directory=False,
+            output_is_directory=True,
             expected_output_file_names=[output_primary_name, "diamond.log"],
             **kwargs,
         )

--- a/toolchest_client/tools/diamond.py
+++ b/toolchest_client/tools/diamond.py
@@ -4,8 +4,6 @@ toolchest_client.tools.Diamond
 
 This is the Diamond implementation of the Tool class.
 """
-import os
-
 from toolchest_client.files import OutputType
 from . import Tool
 

--- a/toolchest_client/tools/kraken2.py
+++ b/toolchest_client/tools/kraken2.py
@@ -13,13 +13,12 @@ class Kraken2(Tool):
     """
     The Kraken2 implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, output_path,
+    def __init__(self, tool_args, inputs, output_path,
                  database_name, database_version, custom_database_path, **kwargs):
         super().__init__(
             tool_name="kraken2",
             tool_version="2.1.1",  # todo: allow kraken 2 version to be set by the user
             tool_args=tool_args,
-            output_name=output_name,
             output_path=output_path,
             inputs=inputs,
             min_inputs=1,
@@ -31,6 +30,6 @@ class Kraken2(Tool):
             parallel_enabled=False,
             output_type=OutputType.S3 if path_is_s3_uri(output_path) else OutputType.GZ_TAR,
             output_is_directory=True,
-            output_names=["kraken2_output.txt", "kraken2_report.txt"],
+            expected_output_file_names=["kraken2_output.txt", "kraken2_report.txt"],
             **kwargs,
         )

--- a/toolchest_client/tools/kraken2.py
+++ b/toolchest_client/tools/kraken2.py
@@ -29,7 +29,6 @@ class Kraken2(Tool):
             max_input_bytes_per_file=64 * 1024 * 1024 * 1024,
             parallel_enabled=False,
             output_type=OutputType.S3 if path_is_s3_uri(output_path) else OutputType.GZ_TAR,
-            output_is_directory=True,
             expected_output_file_names=["kraken2_output.txt", "kraken2_report.txt"],
             **kwargs,
         )

--- a/toolchest_client/tools/megahit.py
+++ b/toolchest_client/tools/megahit.py
@@ -38,8 +38,8 @@ class Megahit(Tool):
 
     def _postflight(self, output):
         if self.output_validation_enabled:
-            for output_name in self.expected_output_file_names:
+            for output_file_name in self.expected_output_file_names:
                 # Skip validation for the "done" file, which should be empty.
-                if output_name != "done":
-                    output_file_path = f"{self.output_path}/{output_name}"
+                if output_file_name != "done":
+                    output_file_path = f"{self.output_path}/{output_file_name}"
                     sanity_check(output_file_path)

--- a/toolchest_client/tools/megahit.py
+++ b/toolchest_client/tools/megahit.py
@@ -25,7 +25,6 @@ class Megahit(Tool):
             max_inputs=None,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=True,
             expected_output_file_names=[
                 "checkpoints.txt",
                 "done",

--- a/toolchest_client/tools/megahit.py
+++ b/toolchest_client/tools/megahit.py
@@ -12,13 +12,12 @@ class Megahit(Tool):
     """
     The megahit implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, input_prefix_mapping,
+    def __init__(self, tool_args, inputs, input_prefix_mapping,
                  output_path, **kwargs):
         super().__init__(
             tool_name="megahit",
             tool_version="1.2.9",  # todo: allow version to be set by the user
             tool_args=tool_args,
-            output_name=output_name,
             output_path=output_path,
             inputs=inputs,
             input_prefix_mapping=input_prefix_mapping,
@@ -27,7 +26,7 @@ class Megahit(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_is_directory=True,
-            output_names=[
+            expected_output_file_names=[
                 "checkpoints.txt",
                 "done",
                 "final.contigs.fa",
@@ -39,7 +38,7 @@ class Megahit(Tool):
 
     def _postflight(self, output):
         if self.output_validation_enabled:
-            for output_name in self.output_names:
+            for output_name in self.expected_output_file_names:
                 # Skip validation for the "done" file, which should be empty.
                 if output_name != "done":
                     output_file_path = f"{self.output_path}/{output_name}"

--- a/toolchest_client/tools/rapsearch2.py
+++ b/toolchest_client/tools/rapsearch2.py
@@ -14,14 +14,13 @@ class Rapsearch2(Tool):
     """
     The Rapsearch implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, output_path,
-                 database_name, database_version, **kwargs):
+    def __init__(self, tool_args, inputs, output_path, database_name,
+                 database_version, **kwargs):
         output_primary_name = os.path.basename(output_path)
         super().__init__(
             tool_name="rapsearch2",
             tool_version="2.24",
             tool_args=tool_args,
-            output_name=output_name,
             output_primary_name=output_primary_name,
             output_path=output_path,
             inputs=inputs,
@@ -32,6 +31,6 @@ class Rapsearch2(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_is_directory=False,
-            output_names=[f"{output_primary_name}.m8"],  # .aln output may be omitted with certain args
+            expected_output_file_names=[f"{output_primary_name}.m8"],  # .aln output may be omitted with certain args
             **kwargs,
         )

--- a/toolchest_client/tools/rapsearch2.py
+++ b/toolchest_client/tools/rapsearch2.py
@@ -27,7 +27,6 @@ class Rapsearch2(Tool):
             database_version=database_version,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=True,
             expected_output_file_names=[f"{output_primary_name}.m8"],  # .aln output may be omitted with certain args
             **kwargs,
         )

--- a/toolchest_client/tools/rapsearch2.py
+++ b/toolchest_client/tools/rapsearch2.py
@@ -4,8 +4,6 @@ toolchest_client.tools.rapsearch
 
 This is the Rapsearch implementation of the Tool class.
 """
-import os
-
 from . import Tool
 from toolchest_client.files import OutputType
 

--- a/toolchest_client/tools/rapsearch2.py
+++ b/toolchest_client/tools/rapsearch2.py
@@ -27,7 +27,7 @@ class Rapsearch2(Tool):
             database_version=database_version,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=False,
+            output_is_directory=True,
             expected_output_file_names=[f"{output_primary_name}.m8"],  # .aln output may be omitted with certain args
             **kwargs,
         )

--- a/toolchest_client/tools/rapsearch2.py
+++ b/toolchest_client/tools/rapsearch2.py
@@ -14,9 +14,8 @@ class Rapsearch2(Tool):
     """
     The Rapsearch implementation of the Tool class.
     """
-    def __init__(self, tool_args, inputs, output_path, database_name,
-                 database_version, **kwargs):
-        output_primary_name = os.path.basename(output_path)
+    def __init__(self, tool_args, inputs, output_path, output_primary_name,
+                 database_name, database_version, **kwargs):
         super().__init__(
             tool_name="rapsearch2",
             tool_version="2.24",

--- a/toolchest_client/tools/shi7.py
+++ b/toolchest_client/tools/shi7.py
@@ -25,7 +25,6 @@ class Shi7(Tool):
             group_paired_ends=True,
             max_input_bytes_per_file=16 * 1024 * 1024 * 1024,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=True,
             expected_output_file_names=["combined_seqs.fna", "shi7.log"],
             **kwargs,
         )

--- a/toolchest_client/tools/shi7.py
+++ b/toolchest_client/tools/shi7.py
@@ -12,12 +12,11 @@ class Shi7(Tool):
     """
     The shi7 implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, output_path, **kwargs):
+    def __init__(self, tool_args, inputs, output_path, **kwargs):
         super().__init__(
             tool_name="shi7",
             tool_version="1.0.3",  # todo: allow shi7 version to be set by the user
             tool_args=tool_args,
-            output_name=output_name,
             output_path=output_path,
             inputs=inputs,
             min_inputs=1,
@@ -27,6 +26,6 @@ class Shi7(Tool):
             max_input_bytes_per_file=16 * 1024 * 1024 * 1024,
             output_type=OutputType.GZ_TAR,
             output_is_directory=True,
-            output_names=["combined_seqs.fna", "shi7.log"],
+            expected_output_file_names=["combined_seqs.fna", "shi7.log"],
             **kwargs,
         )

--- a/toolchest_client/tools/shogun.py
+++ b/toolchest_client/tools/shogun.py
@@ -26,7 +26,6 @@ class ShogunAlign(Tool):
             database_version=database_version,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=True,
             expected_output_file_names=["alignment.bowtie2.sam"],
             **kwargs,
         )
@@ -50,7 +49,6 @@ class ShogunFilter(Tool):
             database_version=database_version,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=True,
             expected_output_file_names=["combined_seqs.filtered.fna", "alignment.burst.best.b6"],
             **kwargs,
         )

--- a/toolchest_client/tools/shogun.py
+++ b/toolchest_client/tools/shogun.py
@@ -12,13 +12,12 @@ class ShogunAlign(Tool):
     """
     The shogun_align implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, output_path,
-                 database_name, database_version, **kwargs):
+    def __init__(self, tool_args, inputs, output_path, database_name,
+                 database_version, **kwargs):
         super().__init__(
             tool_name="shogun_align",
             tool_version="1.0.8",  # todo: allow shogun version to be set by the user
             tool_args=tool_args,
-            output_name=output_name,
             output_path=output_path,
             inputs=inputs,
             min_inputs=1,
@@ -28,7 +27,7 @@ class ShogunAlign(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_is_directory=True,
-            output_names=["alignment.bowtie2.sam"],
+            expected_output_file_names=["alignment.bowtie2.sam"],
             **kwargs,
         )
 
@@ -37,13 +36,12 @@ class ShogunFilter(Tool):
     """
     The shogun_filter implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, output_path,
-                 database_name, database_version, **kwargs):
+    def __init__(self, tool_args, inputs, output_path, database_name,
+                 database_version, **kwargs):
         super().__init__(
             tool_name="shogun_filter",
             tool_version="1.0.8",  # todo: allow shogun version to be set by the user
             tool_args=tool_args,
-            output_name=output_name,
             output_path=output_path,
             inputs=inputs,
             min_inputs=1,
@@ -53,6 +51,6 @@ class ShogunFilter(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_is_directory=True,
-            output_names=["combined_seqs.filtered.fna", "alignment.burst.best.b6"],
+            expected_output_file_names=["combined_seqs.filtered.fna", "alignment.burst.best.b6"],
             **kwargs,
         )

--- a/toolchest_client/tools/star.py
+++ b/toolchest_client/tools/star.py
@@ -16,14 +16,14 @@ class STARInstance(Tool):
     """
     The STAR implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, input_prefix_mapping,
-                 output_path, database_name, database_version, parallelize, **kwargs):
+    def __init__(self, tool_args, inputs, input_prefix_mapping, output_path,
+                 database_name, database_version, parallelize, output_primary_name=None, **kwargs):
         super().__init__(
             tool_name="STAR",
             tool_version="2.7.9a",
             tool_args=tool_args,
-            output_name=output_name,
             output_path=output_path,
+            output_primary_name=output_primary_name,
             inputs=inputs,
             input_prefix_mapping=input_prefix_mapping,
             min_inputs=1,
@@ -35,7 +35,7 @@ class STARInstance(Tool):
             max_input_bytes_per_file_parallel=4.5 * 1024 * 1024 * 1024,
             output_type=OutputType.SAM_FILE if parallelize else OutputType.GZ_TAR,
             output_is_directory=not parallelize,
-            output_names=[
+            expected_output_file_names=[
                 "Aligned.out.sam",
                 "Log.final.out",
                 "Log.out",

--- a/toolchest_client/tools/star.py
+++ b/toolchest_client/tools/star.py
@@ -34,7 +34,6 @@ class STARInstance(Tool):
             max_input_bytes_per_file=128 * 1024 * 1024 * 1024,
             max_input_bytes_per_file_parallel=4.5 * 1024 * 1024 * 1024,
             output_type=OutputType.SAM_FILE if parallelize else OutputType.GZ_TAR,
-            output_is_directory=not parallelize,
             expected_output_file_names=[
                 "Aligned.out.sam",
                 "Log.final.out",

--- a/toolchest_client/tools/test.py
+++ b/toolchest_client/tools/test.py
@@ -25,7 +25,6 @@ class Test(Tool):
             max_input_bytes_per_file=256 * 1024 * 1024 * 1024,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=True,
             expected_output_file_names=["test_output.txt"],
             **kwargs,
         )

--- a/toolchest_client/tools/test.py
+++ b/toolchest_client/tools/test.py
@@ -13,12 +13,11 @@ class Test(Tool):
     """
     The test implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, output_path, **kwargs):
+    def __init__(self, tool_args, inputs, output_path, **kwargs):
         super().__init__(
             tool_name="test",
             tool_version="0.1.0",
             tool_args=tool_args,
-            output_name=output_name,
             output_path=output_path,
             inputs=inputs,
             min_inputs=1,
@@ -27,6 +26,6 @@ class Test(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_is_directory=True,
-            output_names=["test_output.txt"],
+            expected_output_file_names=["test_output.txt"],
             **kwargs,
         )

--- a/toolchest_client/tools/tests/test_generic.py
+++ b/toolchest_client/tools/tests/test_generic.py
@@ -12,7 +12,6 @@ def test_unknown_arg_handling():
         tool_args=tool_args,
         inputs=f"{THIS_DIRECTORY}/test_generic.py",
         output_path="./output.tar.gz",
-        output_name='output',
     )
 
     with pytest.raises(ValueError):
@@ -25,7 +24,6 @@ def test_blacklisted_arg_handling():
         tool_args=tool_args,
         inputs=f"{THIS_DIRECTORY}/test_generic.py",
         output_path="./output.tar.gz",
-        output_name='output',
     )
 
     with pytest.raises(ValueError):

--- a/toolchest_client/tools/tests/test_kraken2.py
+++ b/toolchest_client/tools/tests/test_kraken2.py
@@ -9,7 +9,6 @@ def test_kraken2_preflight():
     output_path = f"{THIS_DIRECTORY}/output"
     kraken_instance = Kraken2(
         tool_args="",
-        output_name='output.tar.gz',
         inputs=f"{THIS_DIRECTORY}/test_kraken2.py",
         output_path=output_path,
         database_name="standard",

--- a/toolchest_client/tools/tests/test_star.py
+++ b/toolchest_client/tools/tests/test_star.py
@@ -8,7 +8,6 @@ THIS_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 def test_star_variable_arg_parsing_single():
     star_instance = STARInstance(
         tool_args="--quantMode GeneCounts --scoreGap 1",
-        output_name='Aligned.out.sam',
         input_prefix_mapping={
             "r1_path": None,
             "r2_path": None,
@@ -27,7 +26,6 @@ def test_star_variable_arg_parsing_single():
 def test_star_variable_arg_parsing_multiple():
     star_instance = STARInstance(
         tool_args="--quantMode TranscriptomeSAM GeneCounts --scoreGap 1",
-        output_name='Aligned.out.sam',
         input_prefix_mapping={
             "r1_path": None,
             "r2_path": None,

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -206,9 +206,8 @@ class Tool:
 
     def _warn_if_outputs_exist(self):
         """Warns if default output files already exist in the output directory"""
-        output_dir = self.output_path if self.output_is_directory else os.path.dirname(self.output_path)
         for file_path in self.expected_output_file_names + ["output", "output.tar.gz"]:
-            joined_file_path = os.path.join(output_dir, file_path)
+            joined_file_path = os.path.join(self.output_path, file_path)
             if os.path.exists(joined_file_path):
                 print(f"WARNING: {joined_file_path} already exists and will be overwritten")
 
@@ -220,18 +219,13 @@ class Tool:
         # Check if the given output_path is a directory, if required by the tool
         # and if the user provides output_path.
         if self._output_path_is_local():
-            if self.output_is_directory:
-                if os.path.exists(self.output_path):
-                    if os.path.isfile(self.output_path):
-                        raise ValueError(
-                            f"{self.output_path} is a file. Please pass a directory instead of an output file."
-                        )
-                else:
-                    os.makedirs(self.output_path, exist_ok=True)
-                self._warn_if_outputs_exist()
+            if os.path.exists(self.output_path):
+                if os.path.isfile(self.output_path):
+                    raise ValueError(
+                        f"{self.output_path} is a file. Please pass a directory instead of an output file."
+                    )
             else:
-                os.makedirs(os.path.dirname(self.output_path), exist_ok=True)
-
+                os.makedirs(self.output_path, exist_ok=True)
             self._warn_if_outputs_exist()
 
     def _postflight(self, output):
@@ -239,14 +233,9 @@ class Tool:
         if self._output_path_is_local() and not self.is_async:
             if self.output_validation_enabled:
                 print("Checking output...")
-                if self.output_is_directory:
-                    for output_file_name in self.expected_output_file_names:
-                        output_file_path = f"{self.output_path}/{output_file_name}"
-                        sanity_check(output_file_path)
-                else:
-                    for output_file_name in self.expected_output_file_names:
-                        output_file_path = f"{os.path.dirname(self.output_path)}/{output_file_name}"
-                        sanity_check(output_file_path)
+                for output_file_name in self.expected_output_file_names:
+                    output_file_path = f"{self.output_path}/{output_file_name}"
+                    sanity_check(output_file_path)
 
     def _system_supports_parallel_execution(self):
         """Checks if parallel execution is supported on the platform.

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -36,8 +36,8 @@ class Tool:
                  max_input_bytes_per_file=FOUR_POINT_FIVE_GIGABYTES,
                  max_input_bytes_per_file_parallel=FOUR_POINT_FIVE_GIGABYTES,
                  group_paired_ends=False, compress_inputs=False,
-                 output_type=OutputType.FLAT_TEXT, output_is_directory=True,
-                 expected_output_file_names=None, is_async=False, skip_decompression=False):
+                 output_type=OutputType.FLAT_TEXT, expected_output_file_names=None,
+                 is_async=False, skip_decompression=False):
         self.tool_name = tool_name
         self.tool_version = tool_version
         self.tool_args = tool_args
@@ -46,7 +46,6 @@ class Tool:
         if self._output_path_is_local():
             # absolutize path, expand user tilde if present
             self.output_path = os.path.abspath(os.path.expanduser(output_path))
-        self.output_is_directory = output_is_directory
         self.inputs = inputs
         # input_prefix_mapping is a dict in the shape of:
         # {
@@ -181,7 +180,6 @@ class Tool:
             # Disable parallelization, validation, and revert to plain compressed output
             self.output_validation_enabled = False
             self.parallel_enabled = False
-            self.output_is_directory = True
             self.output_type = OutputType.GZ_TAR
 
         sanitized_args = " ".join(sanitized_args)

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -14,6 +14,8 @@ import sys
 from threading import Thread
 import time
 
+import sentry_sdk
+
 from toolchest_client.api.auth import validate_key
 from toolchest_client.api.exceptions import ToolchestException
 from toolchest_client.api.output import Output
@@ -279,6 +281,7 @@ class Tool:
         if self.terminating:
             raise InterruptedError("Toolchest client force killed")
         self.terminating = True
+        sentry_sdk.set_tag('send_page', False)
         self._kill_query_threads()
         raise InterruptedError(f"Toolchest client interrupted by signal #{signal_number}")
 

--- a/toolchest_client/tools/unicycler.py
+++ b/toolchest_client/tools/unicycler.py
@@ -13,13 +13,12 @@ class Unicycler(Tool):
     """
     The unicycler implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, input_prefix_mapping,
+    def __init__(self, tool_args, inputs, input_prefix_mapping,
                  output_path, **kwargs):
         super().__init__(
             tool_name="unicycler",
             tool_version="0.4.9",  # todo: allow unicycler version to be set by the user
             tool_args=tool_args,
-            output_name=output_name,
             output_path=output_path,
             inputs=inputs,
             input_prefix_mapping=input_prefix_mapping,
@@ -28,6 +27,6 @@ class Unicycler(Tool):
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_is_directory=True,
-            output_names=["assembly.fasta", "unicycler.log"],
+            expected_output_file_names=["assembly.fasta", "unicycler.log"],
             **kwargs,
         )

--- a/toolchest_client/tools/unicycler.py
+++ b/toolchest_client/tools/unicycler.py
@@ -26,7 +26,6 @@ class Unicycler(Tool):
             max_inputs=3,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
-            output_is_directory=True,
             expected_output_file_names=["assembly.fasta", "unicycler.log"],
             **kwargs,
         )


### PR DESCRIPTION
* Refactors `output_path` to refer _only_ to a directory. If a tool needs a file name specified as well, it should be passed into the `output_primary_name` parameter.
* Removes redundant output variables (`output_name`) and all logic related to whether `output_path` is a directory.
* Adds the `output_path` parameter in `Output.download()`. This should be used in place of the `output_dir` parameter, though the `output_dir` parameter is still supported for backwards compatibility.

This is a **breaking change**. The function calls for the following tools are affected:
* `clustalo`
* `diamond_blastp`
* `diamond_blastx`
* `rapsearch2`

For these tools, `output_path` formerly referred to an output **file**. The base file name should now be parsed into `output_primary_name` instead, and `output_path` should contain the directory the output file will be in.