### PR TITLE
fix: temporarily disable sentry event capture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.9.10"
+version = "0.9.11"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -36,6 +36,6 @@ from .tools.api import alphafold, bowtie2, cellranger_count, clustalo, demucs, d
 sentry_sdk.init(
     "https://c7db7e7a4ac349cc974c55f1fcb7d2f7@o1171636.ingest.sentry.io/6271973",
 
-    traces_sample_rate=1.0,
+    traces_sample_rate=0.0,
     environment=os.getenv("DEPLOY_ENVIRONMENT", 'production')
 )


### PR DESCRIPTION
Disabling sentry until we added a method to limit sentry scope.