### PR TITLE
fix: upload/download tracker bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ toolchest_client/demo.py
 
 # Default temporary directory for splitting input files
 temp_toolchest*
+
+# Default directories for local runs of integration tests
+test_*

--- a/toolchest_client/files/s3.py
+++ b/toolchest_client/files/s3.py
@@ -4,6 +4,7 @@ toolchest_client.files.s3
 
 Functions for handling files in AWS S3 buckets.
 """
+import math
 import os.path
 import sys
 import threading
@@ -103,6 +104,16 @@ def inputs_are_in_s3(input_paths):
     return [path_is_s3_uri(file_path) for file_path in input_paths]
 
 
+def pretty_print_file_size(num_bytes):
+    """Returns a pretty formatted number of bytes (e.g. 1.80MB)
+
+    :param num_bytes size of file in bytes
+    """
+    pretty_abbreviation = ["B", "KB", "MB", "GB", "TB"]
+    abbreviation_index = math.floor(math.log(num_bytes, 1024))
+    return f"{(num_bytes / (1024 ** abbreviation_index)):.1f}{pretty_abbreviation[abbreviation_index]}"
+
+
 class UploadTracker:
     def __init__(self, file_path):
         self._filename = os.path.basename(file_path)
@@ -117,10 +128,10 @@ class UploadTracker:
             self._seen_so_far += bytes_amount
             percentage = round((self._seen_so_far / self._size) * 100, 2)
             print(
-                "\r{}  {} / {} bytes ({:.2f}%)".format(
+                "\r{}  {} of {} ({:.2f}%)".format(
                     self._filename,
-                    self._seen_so_far,
-                    self._size,
+                    pretty_print_file_size(self._seen_so_far),
+                    pretty_print_file_size(self._size),
                     percentage
                 ).ljust(100),  # pads right end with spaces to flush carriage return
                 end="",
@@ -144,10 +155,10 @@ class DownloadTracker:
             self._seen_so_far += bytes_amount
             percentage = round((self._seen_so_far / self._size) * 100, 2)
             print(
-                "\r{}  {} / {} bytes ({:.2f}%)".format(
+                "\r{}  {} of {} ({:.2f}%)".format(
                     self._filename,
-                    self._seen_so_far,
-                    self._size,
+                    pretty_print_file_size(self._seen_so_far),
+                    pretty_print_file_size(self._size),
                     percentage
                 ).ljust(100),  # pads right end with spaces to flush carriage return
                 end="",

--- a/toolchest_client/files/s3.py
+++ b/toolchest_client/files/s3.py
@@ -123,7 +123,8 @@ class UploadTracker:
                     self._size,
                     percentage
                 ).ljust(100),  # pads right end with spaces to flush carriage return
-                flush=True
+                end="",
+                flush=True,
             )
             if percentage == 100.00:  # Adds newline at end of upload
                 print()
@@ -149,7 +150,8 @@ class DownloadTracker:
                     self._size,
                     percentage
                 ).ljust(100),  # pads right end with spaces to flush carriage return
-                flush=True
+                end="",
+                flush=True,
             )
             if percentage == 100.00:  # Adds newline at end of download
                 print()

--- a/toolchest_client/files/s3.py
+++ b/toolchest_client/files/s3.py
@@ -121,7 +121,7 @@ class UploadTracker:
             self._seen_so_far += bytes_amount
             percentage = round((self._seen_so_far / self._size) * 100, 2)
             print(
-                "\r{}  {} / {} bytes ({:.2f}%%)".format(
+                "\r{}  {} / {} bytes ({:.2f}%)".format(
                     self._filename,
                     self._seen_so_far,
                     self._size,
@@ -147,7 +147,7 @@ class DownloadTracker:
             self._seen_so_far += bytes_amount
             percentage = round((self._seen_so_far / self._size) * 100, 2)
             print(
-                "\r{}  {} / {} bytes ({:.2f}%%)".format(
+                "\r{}  {} / {} bytes ({:.2f}%)".format(
                     self._filename,
                     self._seen_so_far,
                     self._size,

--- a/toolchest_client/files/s3.py
+++ b/toolchest_client/files/s3.py
@@ -103,14 +103,10 @@ def inputs_are_in_s3(input_paths):
     return [path_is_s3_uri(file_path) for file_path in input_paths]
 
 
-# Slightly modified from https://boto3.amazonaws.com/v1/documentation/api/latest/_modules/boto3/s3/transfer.html
 class UploadTracker:
     def __init__(self, file_path):
         self._filename = os.path.basename(file_path)
-        if path_is_s3_uri(file_path):
-            self._size = get_s3_file_size(file_path)
-        else:
-            self._size = float(os.path.getsize(file_path))
+        self._size = float(os.path.getsize(file_path))  # tracker only used for local files
         self._seen_so_far = 0
         self._lock = threading.Lock()
 

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -317,8 +317,8 @@ class Tool:
             for thread in self.query_threads:
                 thread_name = thread.getName()
                 statuses.append(self.query_thread_statuses.get(thread_name))
-            uploading = all(
-                map(lambda status: status not in [ThreadStatus.UPLOADING, ThreadStatus.INITIALIZED], statuses)
+            uploading = any(
+                map(lambda status: status in [ThreadStatus.INITIALIZED, ThreadStatus.UPLOADING], statuses)
             )
             time.sleep(5)
         print("Finished spawning jobs.")


### PR DESCRIPTION
* Refactors the tracking printed statements into a pythonic `print` call with string formatting.
* Fixes status update logic in uploading. (This was causing the terminal output to stall at the "uploading" stage.)
* Adds integration test dirs to `.gitignore`.