### PR TITLE
fix: upload tracker status check

### DIFF
--- a/tests/test_shogun.py
+++ b/tests/test_shogun.py
@@ -17,9 +17,9 @@ def test_shogun_filter_and_align():
 
     test_dir = "./test_shogun_filter_and_align"
     os.makedirs(f"{test_dir}", exist_ok=True)
-    input_file_path = f"./{test_dir}/combined_seqs_unfiltered.fna"
-    output_file_path_filter = f"./{test_dir}/combined_seqs.filtered.fna"
-    output_file_path_align = f"./{test_dir}/alignment.bowtie2.sam"
+    input_file_path = f"{test_dir}/combined_seqs_unfiltered.fna"
+    output_file_path_filter = f"{test_dir}/combined_seqs.filtered.fna"
+    output_file_path_align = f"{test_dir}/alignment.bowtie2.sam"
 
     s3.download_integration_test_input(
         s3_file_key="combined_seqs_unfiltered.fna",

--- a/toolchest_client/api/status.py
+++ b/toolchest_client/api/status.py
@@ -46,6 +46,7 @@ class Status(str, Enum):
 class ThreadStatus(str, Enum):
     """Status values for local threads"""
 
+    INITIALIZING = "initializing"
     INITIALIZED = "initialized"
     UPLOADING = "uploading"
     EXECUTING = "executing"

--- a/toolchest_client/files/s3.py
+++ b/toolchest_client/files/s3.py
@@ -138,7 +138,7 @@ class UploadTracker:
                 flush=True,
             )
             if percentage == 100.00:  # Adds newline at end of upload
-                print()
+                print(flush=True)
 
 
 class DownloadTracker:
@@ -165,4 +165,4 @@ class DownloadTracker:
                 flush=True,
             )
             if percentage == 100.00:  # Adds newline at end of download
-                print()
+                print(flush=True)

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -270,7 +270,7 @@ class Tool:
         # Jupyter notebooks and Windows don't always support the canonical "clear-to-end-of-line" escape sequence
         max_length = 120
         status_message = f"\r{job_count} | {jobs_duration} {status_count}"
-        print(f"{status_message}{(max_length - len(status_message)) * ' '}", end="\r")
+        print(f"{status_message}".ljust(max_length), end="\r")
 
     def _handle_termination(self, signal_number, *_):
         """
@@ -318,7 +318,8 @@ class Tool:
                 thread_name = thread.getName()
                 statuses.append(self.query_thread_statuses.get(thread_name))
             uploading = any(
-                map(lambda status: status in [ThreadStatus.INITIALIZED, ThreadStatus.UPLOADING], statuses)
+                map(lambda status: status in [ThreadStatus.INITIALIZING, ThreadStatus.INITIALIZED,
+                                              ThreadStatus.UPLOADING], statuses)
             )
             time.sleep(5)
         print("Finished spawning jobs.")
@@ -443,6 +444,7 @@ class Tool:
 
             new_thread = Thread(target=q.run_query, kwargs=query_args)
             self.query_threads.append(new_thread)
+            self.query_thread_statuses[new_thread.getName()] = ThreadStatus.INITIALIZING
 
             print(f"Spawning job #{len(self.query_threads)}...")
             new_thread.start()


### PR DESCRIPTION
* Adds `INITIALIZING` as a `ThreadStatus`. 
* Sets all query threads to `INITIALIZING` before starting them, so that the `uploading` check in `_wait_for_threads_to_finish` correctly detects when all threads are done uploading. 
* Cleans pretty print status code line.

(This was the cause of the upload tracker display bug.)