### PR TITLE
fix: remove status msg if run failed

### DIFF
--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -331,7 +331,10 @@ class Tool:
                 self._pretty_print_pipeline_segment_status(elapsed_seconds)
                 elapsed_seconds += increment_seconds
                 time.sleep(increment_seconds)
-            self._pretty_print_pipeline_segment_status(elapsed_seconds)
+            thread_name = thread.getName()
+            thread_final_status = self.query_thread_statuses.get(thread_name)
+            if thread_final_status == ThreadStatus.COMPLETE:
+                self._pretty_print_pipeline_segment_status(elapsed_seconds)
         print("")
 
         # Double check all threads are complete for safety


### PR DESCRIPTION
Removes the last printed status message (between the error output and the "job failed" message) if a job did not finish successfully. For example:

```
<rest of error message>
Error: The sequences are expected to be proteins but only contain DNA letters.

Running 1 job | Duration: 0:01:05 | 1 job executing  // this line gets removed by this PR

Toolchest run failed. For support, contact Toolchest with the error log (above) and the following details:

run_id:         "example-run-id"
```