### PR TITLE
Add support for adding and updating custom databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,3 @@ toolchest_client/demo.py
 
 # Default temporary directory for splitting input files
 temp_toolchest*
-
-# Default directories for local runs of integration tests
-test_*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.9.10"
+version = "0.9.13"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/tests/test_database_update.py
+++ b/tests/test_database_update.py
@@ -1,0 +1,66 @@
+import os
+import time
+import pytest
+
+import toolchest_client as toolchest
+
+toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
+if toolchest_api_key:
+    toolchest.set_key(toolchest_api_key)
+
+os.environ["BASE_URL"] = "http://localhost:3001"
+
+
+@pytest.mark.integration
+def test_database_update_s3():
+    """
+    Tests custom database update for Kraken 2 and the standard database
+    """
+    output = toolchest.update_database(
+        database_path="s3://toolchest-integration-tests/arbitrary_directory/",
+        tool=toolchest.tools.Kraken2,
+        database_name="standard",
+    )
+
+    assert output.database_name == "standard"
+    assert output.database_version
+
+
+@pytest.mark.integration
+def test_database_update_local():
+    """
+    Tests custom database update for diamond blastp using a local file
+    """
+    test_dir = "test_database_update_local"
+    os.makedirs(f"./{test_dir}", exist_ok=True)
+    test_file_one = f"{test_dir}/test.fasta"
+    test_file_two = f"{test_dir}/test.fastq"
+
+    open(test_file_one, "w").close()
+    open(test_file_two, "w").close()
+
+    output = toolchest.update_database(
+        database_path=test_dir,
+        tool=toolchest.tools.Kraken2,
+        database_name="standard",
+    )
+
+    assert output.database_name == "standard"
+    assert output.database_version
+
+
+@pytest.mark.integration
+def test_database_add_s3():
+    """
+    Tests custom database addition for Kraken 2
+    """
+    output = toolchest.add_database(
+        database_path="s3://toolchest-integration-tests/arbitrary_directory/",
+        tool=toolchest.tools.Kraken2,
+        database_name=f"new_name_{time.time()}",
+    )
+
+    print(output)
+
+    assert output.database_name.startswith("new_name_")
+    assert output.database_version == "1"

--- a/tests/test_database_update.py
+++ b/tests/test_database_update.py
@@ -8,8 +8,6 @@ toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
 if toolchest_api_key:
     toolchest.set_key(toolchest_api_key)
 
-os.environ["BASE_URL"] = "http://localhost:3001"
-
 
 @pytest.mark.integration
 def test_database_update_s3():

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -31,11 +31,11 @@ from toolchest_client.api.query import Query
 from toolchest_client.api.status import Status, get_status
 from toolchest_client.api.urls import get_api_url, set_api_url
 from .tools.api import alphafold, bowtie2, cellranger_count, clustalo, demucs, diamond_blastp, diamond_blastx, kraken2,\
-    megahit, rapsearch, rapsearch2, shi7, shogun_align, shogun_filter, STAR, test, unicycler
+    megahit, rapsearch, rapsearch2, shi7, shogun_align, shogun_filter, STAR, test, unicycler, update_database
 
 sentry_sdk.init(
     "https://c7db7e7a4ac349cc974c55f1fcb7d2f7@o1171636.ingest.sentry.io/6271973",
 
-    traces_sample_rate=1.0,
+    traces_sample_rate=0.0,
     environment=os.getenv("DEPLOY_ENVIRONMENT", 'production')
 )

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -35,8 +35,8 @@ from .tools.api import add_database, alphafold, bowtie2, cellranger_count, clust
     update_database
 
 sentry_sdk.init(
-    "",
+    "https://c7db7e7a4ac349cc974c55f1fcb7d2f7@o1171636.ingest.sentry.io/6271973",
 
-    traces_sample_rate=0.0,
+    traces_sample_rate=1.0,
     environment=os.getenv("DEPLOY_ENVIRONMENT", 'production')
 )

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -30,11 +30,12 @@ from toolchest_client.api.exceptions import ToolchestException, DataLimitError, 
 from toolchest_client.api.query import Query
 from toolchest_client.api.status import Status, get_status
 from toolchest_client.api.urls import get_api_url, set_api_url
-from .tools.api import alphafold, bowtie2, cellranger_count, clustalo, demucs, diamond_blastp, diamond_blastx, kraken2,\
-    megahit, rapsearch, rapsearch2, shi7, shogun_align, shogun_filter, STAR, test, unicycler, update_database
+from .tools.api import add_database, alphafold, bowtie2, cellranger_count, clustalo, demucs, diamond_blastp, \
+    diamond_blastx, kraken2, megahit, rapsearch, rapsearch2, shi7, shogun_align, shogun_filter, STAR, test, unicycler, \
+    update_database
 
 sentry_sdk.init(
-    "https://c7db7e7a4ac349cc974c55f1fcb7d2f7@o1171636.ingest.sentry.io/6271973",
+    "",
 
     traces_sample_rate=0.0,
     environment=os.getenv("DEPLOY_ENVIRONMENT", 'production')

--- a/toolchest_client/api/output.py
+++ b/toolchest_client/api/output.py
@@ -23,6 +23,8 @@ class Output:
     """
 
     def __init__(self, s3_uri=None, output_path=None, run_id=None):
+        self.database_name = None
+        self.database_version = None
         self.s3_uri = s3_uri
         self.output_path = output_path
         self.run_id = run_id
@@ -41,6 +43,14 @@ class Output:
 
     def set_output_path(self, output_path):
         self.output_path = output_path
+
+    def set_database(self, database_name=None, database_version=None):
+        """Sets the database name and database version for ensuring versioning and reproducibility.
+
+        `database_version` increments when updating a database through the API.
+        """
+        self.database_name = database_name
+        self.database_version = database_version
 
     def download(self, output_path=None, output_dir=None, skip_decompression=False):
         if not output_path:

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -80,13 +80,13 @@ class Query:
         :param database_name: Name of database to be used.
         :param database_version: Version of database to be used.
         :param custom_database_path: Path (S3 URI) to a custom database.
-        :param input_prefix_mapping: Mapping of input filepaths to associated prefix tags (e.g., "-1")
-        :param is_database_update: Whether the call is to udpate an existing Toolchest DB
+        :param input_prefix_mapping: Mapping of input filepaths to associated prefix tags (e.g., "-1").
+        :param is_database_update: Whether the call is to update an existing database.
         :param output_primary_name: (optional) basename of the primary output (e.g. "sample.fastq").
         :param input_files: List of paths to be passed in as input.
         :param output_path: Path (client-side) where the output file will be downloaded.
-        :param output_type: Type (e.g. GZ_TAR) of the output file
-        :param skip_decompression: Whether to skip decompression of the output file, if it is an archive
+        :param output_type: Type (e.g. GZ_TAR) of the output file.
+        :param skip_decompression: Whether to skip decompression of the output file, if it is an archive.
         :param thread_statuses: Statuses of all threads, shared between threads.
         """
         self.thread_name = threading.current_thread().getName()

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -69,8 +69,9 @@ class Query:
 
     def run_query(self, tool_name, tool_version, input_prefix_mapping,
                   output_type, tool_args=None, database_name=None, database_version=None,
-                  custom_database_path=None, output_primary_name=None,
-                  input_files=None, output_path=None, skip_decompression=False, thread_statuses=None):
+                  custom_database_path=None, input_files=None, is_database_update=False,
+                  output_path=None, output_primary_name=None, skip_decompression=False,
+                  thread_statuses=None):
         """Executes a query to the Toolchest API.
 
         :param tool_name: Tool to be used.
@@ -80,6 +81,7 @@ class Query:
         :param database_version: Version of database to be used.
         :param custom_database_path: Path (S3 URI) to a custom database.
         :param input_prefix_mapping: Mapping of input filepaths to associated prefix tags (e.g., "-1")
+        :param is_database_update: Whether the call is to udpate an existing Toolchest DB
         :param output_primary_name: (optional) basename of the primary output (e.g. "sample.fastq").
         :param input_files: List of paths to be passed in as input.
         :param output_path: Path (client-side) where the output file will be downloaded.
@@ -98,11 +100,12 @@ class Query:
             database_name=database_name,
             database_version=database_version,
             custom_database_path=custom_database_path,
-            output_primary_name=output_primary_name,
+            is_database_update=is_database_update,
             tool_name=tool_name,
             tool_version=tool_version,
             tool_args=tool_args,
             output_file_path=output_path,
+            output_primary_name=output_primary_name,
         )
         create_content = create_response.json()
 
@@ -119,6 +122,10 @@ class Query:
         ])
 
         self.output.set_run_id(self.PIPELINE_SEGMENT_INSTANCE_ID)
+        self.output.set_database(
+            database_name=create_content["database_name"],
+            database_version=create_content["database_version"],
+        )
         self.mark_as_failed = True
 
         self._check_if_should_terminate()
@@ -145,7 +152,8 @@ class Query:
 
     def _send_initial_request(self, tool_name, tool_version, tool_args,
                               database_name, database_version, custom_database_path,
-                              output_primary_name, output_file_path, compress_output):
+                              output_primary_name, output_file_path, compress_output,
+                              is_database_update):
         """Sends the initial request to the Toolchest API to create the query.
 
         Returns the response from the POST request.
@@ -157,10 +165,12 @@ class Query:
             "custom_database_s3_location": custom_database_path,
             "database_name": database_name,
             "database_version": database_version,
-            "output_file_primary_name": output_primary_name,
+            "is_database_update": is_database_update,
             "tool_name": tool_name,
             "tool_version": tool_version,
             "output_file_path": output_file_path,
+            "output_file_primary_name": output_primary_name,
+
         }
 
         create_response = requests.post(

--- a/toolchest_client/tools/alphafold.py
+++ b/toolchest_client/tools/alphafold.py
@@ -18,8 +18,6 @@ class AlphaFold(Tool):
             tool_version="2.1.2",
             tool_args=tool_args,
             inputs=inputs,
-            min_inputs=1,
-            max_inputs=1,
             database_name="alphafold_standard",
             database_version="2.1.2",
             parallel_enabled=False,

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -187,30 +187,35 @@ def demucs(inputs, output_path=None, tool_args="", **kwargs):
     return output
 
 
-def diamond_blastp(inputs, output_path=None, output_primary_name="out_file.tsv", tool_args="", **kwargs):
+def diamond_blastp(inputs, output_path=None, database_name="diamond_blastp_standard", database_version="1",
+                   output_primary_name="out_file.tsv", tool_args="", **kwargs):
     """Runs diamond blastp via Toolchest.
 
-      :param inputs: Path to a file that will be passed in as input. FASTA or FASTQ formats are supported (it may be
-        gzip compressed)
-      :param output_path: (optional) (optional) Path to directory where the output file(s) will be downloaded.
-        Log file (diamond.log) will be downloaded in the same directory as the out file(s).
-      :param output_primary_name: (optional) Base name of output file.
-      :param tool_args: Additional arguments to be passed to diamond blastp.
+    :param inputs: Path to a file that will be passed in as input. FASTA or FASTQ formats are supported (it may be
+    gzip compressed)
+    :param database_name: (optional) Name of database to use for DIAMOND BLASTP.
+    :param database_version: (optional) Version of database to use for DIAMOND BLASTP.
+    :param output_path: (optional) (optional) Path to directory where the output file(s) will be downloaded.
+    Log file (diamond.log) will be downloaded in the same directory as the out file(s).
+    :param output_primary_name: (optional) Base name of output file.
+    :param tool_args: Additional arguments to be passed to diamond blastp.
 
-      Usage::
+    Usage::
 
-          >>> import toolchest_client as toolchest
-          >>> toolchest.diamond_blastp(
-          ...     tool_args="",
-          ...     inputs="./path/to/input.fa",
-          ...     output_path="./path/to/output/",
-          ...     output_primary_name="out_file.tsv",
-          ... )
+      >>> import toolchest_client as toolchest
+      >>> toolchest.diamond_blastp(
+      ...     tool_args="",
+      ...     inputs="./path/to/input.fa",
+      ...     output_path="./path/to/output/",
+      ...     output_primary_name="out_file.tsv",
+      ... )
 
       """
     instance = DiamondBlastp(
         inputs=inputs,
         output_path=output_path,
+        database_name=database_name,
+        database_version=database_version,
         output_primary_name=output_primary_name,
         tool_args=tool_args,
         **kwargs,
@@ -219,27 +224,32 @@ def diamond_blastp(inputs, output_path=None, output_primary_name="out_file.tsv",
     return output
 
 
-def diamond_blastx(inputs, output_path=None, output_primary_name="out_file.tsv", tool_args="", **kwargs):
+def diamond_blastx(inputs, output_path=None, database_name="diamond_blastx_standard", database_version="1",
+                   output_primary_name="out_file.tsv", tool_args="", **kwargs):
     """Runs diamond blastx via Toolchest.
-      :param inputs: Path to a file that will be passed in as input. FASTA or FASTQ formats are supported (it may be
-        gzip compressed)
-      :param output_path: (optional) (optional) Path to directory where the output file(s) will be downloaded.
-        Log file (diamond.log) will be downloaded in the same directory as the out file(s).
-      :param output_primary_name: (optional) Base name of output file.
-      :param tool_args: Additional arguments to be passed to diamond blastx.
-      Usage::
+    :param inputs: Path to a file that will be passed in as input. FASTA or FASTQ formats are supported (it may be
+gzip compressed)
+    :param database_name: (optional) Name of database to use for DIAMOND BLASTX.
+    :param database_version: (optional) Version of database to use for DIAMOND BLASTX.
+    :param output_path: (optional) (optional) Path to directory where the output file(s) will be downloaded.
+    Log file (diamond.log) will be downloaded in the same directory as the out file(s).
+    :param output_primary_name: (optional) Base name of output file.
+    :param tool_args: (optional) Additional arguments to be passed to diamond blastx.
+    Usage::
 
-          >>> import toolchest_client as toolchest
-          >>> toolchest.diamond_blastx(
-          ...     tool_args="",
-          ...     inputs="./path/to/input.fa",
-          ...     output_path="./path/to/output/",
-          ...     output_primary_name="out_file.tsv",
-          ... )
+        >>> import toolchest_client as toolchest
+        >>> toolchest.diamond_blastx(
+        ...     tool_args="",
+        ...     inputs="./path/to/input.fa",
+        ...     output_path="./path/to/output/",
+        ...     output_primary_name="out_file.tsv",
+        ... )
 
       """
     instance = DiamondBlastx(
         inputs=inputs,
+        database_name=database_name,
+        database_version=database_version,
         output_path=output_path,
         output_primary_name=output_primary_name,
         tool_args=tool_args,
@@ -630,18 +640,26 @@ def unicycler(output_path=None, read_one=None, read_two=None, long_reads=None, t
     return output
 
 
-def update_database(updated_database, tool, database_name, **kwargs):
-    """Updates a database
+def update_database(database_path, tool, database_name, **kwargs):
+    """Updates a custom database. The new database version is returned immediately after initialization.
 
-    :param updated_database: Path or list of paths (local or S3) to be passed in as inputs.
-    :param tool: Toolchest tool with which you use the database (e.g. toolchest.tools.kraken2).
+    This executes just like any other tool, except:
+    - the success status is
+    toolchest_client.api.status.COMPLETE ('complete') instead of
+    toolchest_client.api.status.READY_TO_TRANSFER_TO_CLIENT ('ready_to_transfer_to_client)
+    - is_async is True by default
+
+    Note that it may take 24-48 hours for the custom database to be ready for use.
+
+    :param database_path: Path or list of paths (local or S3) to be passed in as inputs.
+    :param tool: Toolchest tool with which you use the database (e.g. toolchest.tools.Kraken2).
     :param database_name: Name of database to update.
 
     Usage::
 
         >>> import toolchest_client as toolchest
         >>> toolchest.update_database(
-        ...     updated_database="s3://toolchest-fsx-databases/kraken2/k2_viral_20210517/",
+        ...     database_path="s3://toolchest-fsx-databases/kraken2/k2_viral_20210517/",
         ...     tool=toolchest.tools.kraken2,
         ...     database_name="standard",
         ... )
@@ -649,7 +667,7 @@ def update_database(updated_database, tool, database_name, **kwargs):
     """
 
     instance = tool(
-        inputs=updated_database,
+        inputs=database_path,
         database_name=database_name,
         is_async=True,
         is_database_update=True,
@@ -658,6 +676,51 @@ def update_database(updated_database, tool, database_name, **kwargs):
         database_version=None,
         tool_args="",
         custom_database_path=None,
+        max_inputs=1000,
+        **kwargs,
+    )
+    output = instance.run()
+    return output
+
+
+def add_database(database_path, tool, database_name, **kwargs):
+    """Adds a custom database and attaches it to a tool.
+    The new database version is returned immediately after initialization.
+
+    This executes just like any other tool, except:
+    - the success status is
+    toolchest_client.api.status.COMPLETE ('complete') instead of
+    toolchest_client.api.status.READY_TO_TRANSFER_TO_CLIENT ('ready_to_transfer_to_client)
+    - is_async is True by default
+
+    Note that it may take 24-48 hours for the custom database to be ready for use.
+
+    :param database_path: Path or list of paths (local or S3) to be passed in as inputs.
+    :param tool: Toolchest tool with which you use the database (e.g. toolchest.tools.Kraken2).
+    :param database_name: Name of the new database.
+
+    Usage::
+
+        >>> import toolchest_client as toolchest
+        >>> toolchest.add_database(
+        ...     database_path="s3://toolchest-fsx-databases/kraken2/k2_viral_20210517/",
+        ...     tool=toolchest.tools.Kraken2,
+        ...     database_name="my_new_database",
+        ... )
+
+    """
+
+    instance = tool(
+        inputs=database_path,
+        database_name=database_name,
+        is_async=True,
+        is_database_update=True,
+        output_path=None,
+        output_primary_name=None,
+        database_version=None,
+        tool_args="",
+        custom_database_path=None,
+        max_inputs=1000,
         **kwargs,
     )
     output = instance.run()

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -628,3 +628,37 @@ def unicycler(output_path=None, read_one=None, read_two=None, long_reads=None, t
     )
     output = instance.run()
     return output
+
+
+def update_database(updated_database, tool, database_name, **kwargs):
+    """Updates a database
+
+    :param updated_database: Path or list of paths (local or S3) to be passed in as inputs.
+    :param tool: Toolchest tool with which you use the database (e.g. toolchest.tools.kraken2).
+    :param database_name: Name of database to update.
+
+    Usage::
+
+        >>> import toolchest_client as toolchest
+        >>> toolchest.update_database(
+        ...     updated_database="s3://toolchest-fsx-databases/kraken2/k2_viral_20210517/",
+        ...     tool=toolchest.tools.kraken2,
+        ...     database_name="standard",
+        ... )
+
+    """
+
+    instance = tool(
+        inputs=updated_database,
+        database_name=database_name,
+        is_async=True,
+        is_database_update=True,
+        output_path=None,
+        output_primary_name=None,
+        database_version=None,
+        tool_args="",
+        custom_database_path=None,
+        **kwargs,
+    )
+    output = instance.run()
+    return output

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -202,13 +202,13 @@ def diamond_blastp(inputs, output_path=None, database_name="diamond_blastp_stand
 
     Usage::
 
-      >>> import toolchest_client as toolchest
-      >>> toolchest.diamond_blastp(
-      ...     tool_args="",
-      ...     inputs="./path/to/input.fa",
-      ...     output_path="./path/to/output/",
-      ...     output_primary_name="out_file.tsv",
-      ... )
+        >>> import toolchest_client as toolchest
+        >>> toolchest.diamond_blastp(
+        ...     tool_args="",
+        ...     inputs="./path/to/input.fa",
+        ...     output_path="./path/to/output/",
+        ...     output_primary_name="out_file.tsv",
+        ... )
 
       """
     instance = DiamondBlastp(

--- a/toolchest_client/tools/bowtie2.py
+++ b/toolchest_client/tools/bowtie2.py
@@ -21,8 +21,6 @@ class Bowtie2(Tool):
             tool_args=tool_args,
             output_path=output_path,
             inputs=inputs,
-            min_inputs=1,
-            max_inputs=1,
             database_name=database_name,
             database_version=database_version,
             parallel_enabled=False,

--- a/toolchest_client/tools/cellranger.py
+++ b/toolchest_client/tools/cellranger.py
@@ -20,8 +20,6 @@ class CellRangerCount(Tool):
             tool_args=tool_args,
             output_path=output_path,
             inputs=inputs,
-            min_inputs=1,
-            max_inputs=1,
             database_name=database_name,
             database_version=database_version,
             compress_inputs=True,

--- a/toolchest_client/tools/clustalo.py
+++ b/toolchest_client/tools/clustalo.py
@@ -20,8 +20,6 @@ class ClustalO(Tool):
             output_primary_name=output_primary_name,
             output_path=output_path,
             inputs=inputs,
-            min_inputs=1,
-            max_inputs=1,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             expected_output_file_names=[output_primary_name, f"{output_primary_name}.log"],

--- a/toolchest_client/tools/demucs.py
+++ b/toolchest_client/tools/demucs.py
@@ -19,8 +19,6 @@ class Demucs(Tool):
             tool_args=tool_args,
             output_path=output_path,
             inputs=inputs,
-            min_inputs=1,
-            max_inputs=1,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             expected_output_file_names=["error.log", "output.log"],

--- a/toolchest_client/tools/diamond.py
+++ b/toolchest_client/tools/diamond.py
@@ -10,19 +10,17 @@ from . import Tool
 
 class DiamondBlastp(Tool):
     """
-    The Diamond Blastp implementation of the Tool class.
+    The DIAMOND BLASTP implementation of the Tool class.
     """
-    def __init__(self, inputs, output_path, output_primary_name, tool_args, **kwargs):
+    def __init__(self, inputs, database_name, database_version, output_path, output_primary_name, tool_args, **kwargs):
         super().__init__(
             tool_name="diamond_blastp",
             tool_version="2.0.14",
             tool_args=tool_args,
             output_primary_name=output_primary_name,
             inputs=inputs,
-            min_inputs=1,
-            max_inputs=1,
-            database_name="diamond_blastp_standard",
-            database_version="1",
+            database_name=database_name,
+            database_version=database_version,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_path=output_path,
@@ -33,19 +31,17 @@ class DiamondBlastp(Tool):
 
 class DiamondBlastx(Tool):
     """
-    The Diamond Blastx implementation of the Tool class.
+    The DIAMOND BLASTX implementation of the Tool class.
     """
-    def __init__(self, inputs, output_path, output_primary_name, tool_args, **kwargs):
+    def __init__(self, inputs,  database_name, database_version, output_path, output_primary_name, tool_args, **kwargs):
         super().__init__(
             tool_name="diamond_blastx",
             tool_version="2.0.13",
             tool_args=tool_args,
             output_primary_name=output_primary_name,
             inputs=inputs,
-            min_inputs=1,
-            max_inputs=1,
-            database_name="diamond_blastx_standard",
-            database_version="1",
+            database_name=database_name,
+            database_version=database_version,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             output_path=output_path,

--- a/toolchest_client/tools/kraken2.py
+++ b/toolchest_client/tools/kraken2.py
@@ -21,8 +21,6 @@ class Kraken2(Tool):
             tool_args=tool_args,
             output_path=output_path,
             inputs=inputs,
-            min_inputs=1,
-            max_inputs=2,
             database_name=database_name,
             database_version=database_version,
             custom_database_path=custom_database_path,

--- a/toolchest_client/tools/megahit.py
+++ b/toolchest_client/tools/megahit.py
@@ -21,7 +21,6 @@ class Megahit(Tool):
             output_path=output_path,
             inputs=inputs,
             input_prefix_mapping=input_prefix_mapping,
-            min_inputs=1,
             max_inputs=None,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,

--- a/toolchest_client/tools/rapsearch2.py
+++ b/toolchest_client/tools/rapsearch2.py
@@ -21,8 +21,6 @@ class Rapsearch2(Tool):
             output_primary_name=output_primary_name,
             output_path=output_path,
             inputs=inputs,
-            min_inputs=1,
-            max_inputs=1,
             database_name=database_name,
             database_version=database_version,
             parallel_enabled=False,

--- a/toolchest_client/tools/shi7.py
+++ b/toolchest_client/tools/shi7.py
@@ -19,7 +19,6 @@ class Shi7(Tool):
             tool_args=tool_args,
             output_path=output_path,
             inputs=inputs,
-            min_inputs=1,
             max_inputs=None,  # note: no limit is set on the # of inputs
             parallel_enabled=False,
             group_paired_ends=True,

--- a/toolchest_client/tools/shogun.py
+++ b/toolchest_client/tools/shogun.py
@@ -20,8 +20,6 @@ class ShogunAlign(Tool):
             tool_args=tool_args,
             output_path=output_path,
             inputs=inputs,
-            min_inputs=1,
-            max_inputs=1,
             database_name=database_name,
             database_version=database_version,
             parallel_enabled=False,

--- a/toolchest_client/tools/star.py
+++ b/toolchest_client/tools/star.py
@@ -26,8 +26,6 @@ class STARInstance(Tool):
             output_primary_name=output_primary_name,
             inputs=inputs,
             input_prefix_mapping=input_prefix_mapping,
-            min_inputs=1,
-            max_inputs=2,
             database_name=database_name,
             database_version=database_version,
             parallel_enabled=False,  # True if parallelize else False

--- a/toolchest_client/tools/test.py
+++ b/toolchest_client/tools/test.py
@@ -20,8 +20,6 @@ class Test(Tool):
             tool_args=tool_args,
             output_path=output_path,
             inputs=inputs,
-            min_inputs=1,
-            max_inputs=100,  # this limit is completely arbitrary
             max_input_bytes_per_file=256 * 1024 * 1024 * 1024,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -39,7 +39,7 @@ class Tool:
                  max_input_bytes_per_file_parallel=FOUR_POINT_FIVE_GIGABYTES,
                  group_paired_ends=False, compress_inputs=False,
                  output_type=OutputType.FLAT_TEXT, expected_output_file_names=None,
-                 is_async=False, skip_decompression=False):
+                 is_async=False, is_database_update=False, skip_decompression=False):
         self.tool_name = tool_name
         self.tool_version = tool_version
         self.tool_args = tool_args
@@ -77,6 +77,7 @@ class Tool:
         self.thread_outputs = {}
         self.expected_output_file_names = expected_output_file_names or []
         self.is_async = is_async
+        self.is_database_update = is_database_update
         self.skip_decompression = skip_decompression
         signal.signal(signal.SIGTERM, self._handle_termination)
         signal.signal(signal.SIGINT, self._handle_termination)

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -31,7 +31,7 @@ FOUR_POINT_FIVE_GIGABYTES = int(4.5 * 1024 * 1024 * 1024)
 
 class Tool:
     def __init__(self, tool_name, tool_version, tool_args,
-                 inputs, min_inputs, max_inputs=None, output_path=None,
+                 inputs, min_inputs=1, max_inputs=100, output_path=None,
                  output_primary_name=None, database_name=None,
                  database_version=None, custom_database_path=None,
                  input_prefix_mapping=None, parallel_enabled=False,
@@ -426,18 +426,19 @@ class Tool:
             # Deep copy to make thread safe
             # Note: multithreaded download may be broken with output_path refactor
             query_args = copy.deepcopy({
+                "custom_database_path": self.custom_database_path,
+                "database_name": self.database_name,
+                "database_version": self.database_version,
+                "input_files": input_files,
+                "input_prefix_mapping": self.input_prefix_mapping,
+                "is_database_update": self.is_database_update,
+                "output_path": temp_parallel_output_file_path if should_run_in_parallel else non_parallel_output_path,
+                "output_primary_name": self.output_primary_name,
+                "output_type": self.output_type,
+                "skip_decompression": self.skip_decompression,
                 "tool_name": self.tool_name,
                 "tool_version": self.tool_version,
                 "tool_args": self.tool_args,
-                "database_name": self.database_name,
-                "database_version": self.database_version,
-                "custom_database_path": self.custom_database_path,
-                "output_primary_name": self.output_primary_name,
-                "input_files": input_files,
-                "input_prefix_mapping": self.input_prefix_mapping,
-                "output_path": temp_parallel_output_file_path if should_run_in_parallel else non_parallel_output_path,
-                "output_type": self.output_type,
-                "skip_decompression": self.skip_decompression,
             })
 
             # Add non-distinct dictionary for status updates
@@ -488,13 +489,13 @@ class Tool:
             if self.is_async:
                 print(
                     f"\nAsync Toolchest initiation is complete! Your run ID is included in the returned object.\n\n"
-                    f"To check the status of this run, call get_status(run_id=\"{run_id}\").\n"
-                    f"Once it's ready to download, call download(run_id=\"{run_id}\", ...) within 7 days\n"
+                    f"To check the status of this run, call toolchest.get_status(run_id=\"{run_id}\").\n"
+                    f"Once it's ready to download, call toolchest.download(run_id=\"{run_id}\", ...) within 7 days\n"
                     )
             else:
                 print(
                     f"\nYour Toolchest run is complete! The run ID and output locations are included in the return.\n\n"
-                    f"If you need to re-download the results, run download(run_id=\"{run_id}\") within 7 days\n"
+                    f"To re-download the results, run toolchest.download(run_id=\"{run_id}\") within 7 days\n"
                     )
 
         # Note: output information is only returned if parallelization is disabled

--- a/toolchest_client/tools/unicycler.py
+++ b/toolchest_client/tools/unicycler.py
@@ -22,8 +22,6 @@ class Unicycler(Tool):
             output_path=output_path,
             inputs=inputs,
             input_prefix_mapping=input_prefix_mapping,
-            min_inputs=1,
-            max_inputs=3,
             parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             expected_output_file_names=["assembly.fasta", "unicycler.log"],


### PR DESCRIPTION
Adds:
- Support for adding or updating custom databases

Removes:
- Tool specific min/max files – these don't seem to be aligned with the underlying tools anymore, and were a guard against opaque errors. Now that we have better error handling, these seem less relevant.