### PR TITLE
refactor: integration test dir names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ toolchest_client/demo.py
 
 # Default temporary directory for splitting input files
 temp_toolchest*
+
+# Integration test directories
+temp_test_*

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -16,7 +16,7 @@ def test_async_execution():
     Tests Kraken 2 running async using a small reference database
     """
 
-    test_dir = "test_async_execution"
+    test_dir = "temp_test_async_execution"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
     output_file_path = f"{output_dir_path}/kraken2_output.txt"

--- a/tests/test_bowtie2.py
+++ b/tests/test_bowtie2.py
@@ -14,7 +14,7 @@ def test_bowtie2():
     Tests bowtie2
     """
 
-    test_dir = "test_bowtie2_standard"
+    test_dir = "temp_test_bowtie2_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}/"
 

--- a/tests/test_cellranger.py
+++ b/tests/test_cellranger.py
@@ -12,7 +12,7 @@ if toolchest_api_key:
 
 @pytest.mark.integration
 def test_cellranger_count_s3_inputs():
-    test_dir = "test_cellranger_count_s3_inputs"
+    test_dir = "temp_test_cellranger_count_s3_inputs"
     output_dir_path = f"./{test_dir}/output/"
 
     # Test using a compressed archive in S3
@@ -27,7 +27,7 @@ def test_cellranger_count_s3_inputs():
 
 @pytest.mark.integration
 def test_cellranger_count_local_inputs():
-    test_dir = "test_cellranger_count_local_inputs"
+    test_dir = "temp_test_cellranger_count_local_inputs"
     input_dir_path = f"./{test_dir}/inputs/"
     output_dir_path = f"./{test_dir}/output/"
     os.makedirs(input_dir_path, exist_ok=True)

--- a/tests/test_chaining.py
+++ b/tests/test_chaining.py
@@ -26,7 +26,7 @@ def test_shi7_shogun_chaining():
     If the Output class is modified, this test should be modified as well.
     """
 
-    test_dir = "test_shi7_shogun_chaining"
+    test_dir = "temp_test_shi7_shogun_chaining"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
     output_file_path_shogun = f"{output_dir_path}/alignment.bowtie2.sam"

--- a/tests/test_clustalo.py
+++ b/tests/test_clustalo.py
@@ -14,7 +14,7 @@ def test_clustalo_standard():
     """
     Tests Clustal Omega
     """
-    test_dir = "test_clustalo_standard"
+    test_dir = "temp_test_clustalo_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
     output_file_name = "sample_output.fasta"

--- a/tests/test_database_update.py
+++ b/tests/test_database_update.py
@@ -29,7 +29,7 @@ def test_database_update_local():
     """
     Tests custom database update for diamond blastp using a local file
     """
-    test_dir = "test_database_update_local"
+    test_dir = "temp_test_database_update_local"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     test_file_one = f"{test_dir}/test.fasta"
     test_file_two = f"{test_dir}/test.fastq"

--- a/tests/test_diamond.py
+++ b/tests/test_diamond.py
@@ -17,7 +17,7 @@ def test_diamond_blastp_standard():
     """
     Tests Diamond blastp mode
     """
-    test_dir = "test_diamond_blastp_standard"
+    test_dir = "temp_test_diamond_blastp_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
     output_file_name = "sample_output.tsv"
@@ -37,7 +37,7 @@ def test_diamond_blastx_standard():
     """
     Tests Diamond blastx mode
     """
-    test_dir = "test_diamond_blastx_standard"
+    test_dir = "temp_test_diamond_blastx_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
     output_file_name = "sample_output.tsv"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -17,7 +17,7 @@ def test_kraken2_output_manual_download():
     Tests Kraken 2 against the standard (v1) database, with
     output manually downloaded after job completion
     """
-    test_dir = "test_kraken2_output_manual_download"
+    test_dir = "temp_test_kraken2_output_manual_download"
     input_file_s3_uri = "s3://toolchest-integration-tests/synthetic_bacteroides_reads.fasta"
     manual_output_dir_path = f"./{test_dir}/manual"
     manual_output_file_path = f"{manual_output_dir_path}/kraken2_output.txt"

--- a/tests/test_filepath.py
+++ b/tests/test_filepath.py
@@ -15,7 +15,7 @@ def test_tilde_filepath():
     Tests Kraken 2 against the standard (v1) database
     """
     input_file_path = "~/kraken_input.fasta"
-    output_dir_path = "~/test_tilde_filepath"
+    output_dir_path = "~/temp_test_tilde_filepath"
     output_file_path = os.path.expanduser(f"{output_dir_path}/kraken2_output.txt")
     os.makedirs(os.path.expanduser(output_dir_path), exist_ok=True)
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -13,7 +13,7 @@ def test_http_input():
     """
     Tests test function with an http input
     """
-    test_dir = "test_http"
+    test_dir = "temp_test_http"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_path = "https://toolchest-public-examples-no-encryption.s3.amazonaws.com/example.fastq"
     output_dir_path = f"./{test_dir}"

--- a/tests/test_kraken2.py
+++ b/tests/test_kraken2.py
@@ -16,7 +16,7 @@ def test_kraken2_standard():
     """
     Tests Kraken 2 against the standard (v1) database
     """
-    test_dir = "test_kraken2_standard"
+    test_dir = "temp_test_kraken2_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_path = "./kraken_input.fasta"
     output_dir_path = f"./{test_dir}"
@@ -40,7 +40,7 @@ def test_kraken2_paired_end():
     """
     Tests Kraken 2 with paired-end inputs against the std (v1) DB
     """
-    test_dir = "test_kraken2_paired_end"
+    test_dir = "temp_test_kraken2_paired_end"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_one_file_path = f"./{test_dir}/kraken_input_read1.fastq.gz"
     input_two_file_path = f"./{test_dir}/kraken_input_read2.fastq.gz"
@@ -71,7 +71,7 @@ def test_kraken2_s3():
     """
     Tests Kraken 2 with an example input in S3 against the std (v1) DB
     """
-    test_dir = "test_kraken2_s3"
+    test_dir = "temp_test_kraken2_s3"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
     output_file_path = f"{output_dir_path}/kraken2_output.txt"
@@ -91,7 +91,7 @@ def test_kraken2_custom_db():
     """
     KRAKEN2_OUTPUT_VIRAL_HASH = 1003212151
 
-    test_dir = "test_kraken2_custom_db"
+    test_dir = "temp_test_kraken2_custom_db"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
     output_file_path = f"{output_dir_path}/kraken2_output.txt"

--- a/tests/test_megahit.py
+++ b/tests/test_megahit.py
@@ -21,7 +21,7 @@ def test_megahit_many_types():
     we check the size of the file instead.
     See https://github.com/voutcn/megahit/issues/48.
     """
-    test_dir = "test_megahit_many_types"
+    test_dir = "temp_test_megahit_many_types"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
     output_file_path = f"{output_dir_path}/final.contigs.fa"
@@ -53,7 +53,7 @@ def test_megahit_multiple_pairs():
     we check the size of the file instead.
     See https://github.com/voutcn/megahit/issues/48.
     """
-    test_dir = "test_megahit_two_pairs"
+    test_dir = "temp_test_megahit_two_pairs"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
     output_file_path = f"{output_dir_path}/final.contigs.fa"

--- a/tests/test_rapsearch2.py
+++ b/tests/test_rapsearch2.py
@@ -15,7 +15,7 @@ def test_rapsearch2():
     Tests rapsearch2 on SeqScreen DB
     """
 
-    test_dir = "./test_rapsearch"
+    test_dir = "./temp_test_rapsearch2"
     os.makedirs(f"{test_dir}", exist_ok=True)
     output_file_path_aln = f"./{test_dir}/rapsearch2.aln"
     output_file_path_m8 = f"./{test_dir}/rapsearch2.m8"

--- a/tests/test_shi7.py
+++ b/tests/test_shi7.py
@@ -22,7 +22,7 @@ def test_shi7_single_end():
     If the Output class is modified, this test should be modified as well.
     """
 
-    test_dir = "./test_shi7_single_end"
+    test_dir = "./temp_test_shi7_single_end"
     os.makedirs(test_dir, exist_ok=True)
     input_one_file_path = f"{test_dir}/shi7_input_R1.fastq.gz"
     output_file_path = f"{test_dir}/combined_seqs.fna"
@@ -55,7 +55,7 @@ def test_shi7_paired_end():
     Because of this, we should not recommend shi7 for use.
     """
 
-    test_dir = "./test_shi7_paired_end"
+    test_dir = "./temp_test_shi7_paired_end"
     os.makedirs(test_dir, exist_ok=True)
     input_one_file_path = f"{test_dir}/shi7_input_R1.fastq.gz"
     input_two_file_path = f"{test_dir}/shi7_input_R2.fastq.gz"

--- a/tests/test_shogun.py
+++ b/tests/test_shogun.py
@@ -15,7 +15,7 @@ def test_shogun_filter_and_align():
     Tests shogun (filter and align for simplicity) with a single R1 input
     """
 
-    test_dir = "./test_shogun_filter_and_align"
+    test_dir = "./temp_test_shogun_filter_and_align"
     os.makedirs(f"{test_dir}", exist_ok=True)
     input_file_path = f"{test_dir}/combined_seqs_unfiltered.fna"
     output_file_path_filter = f"{test_dir}/combined_seqs.filtered.fna"

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -14,7 +14,7 @@ def test_star_grch38():
     """
     Tests STAR against the grch38 database
     """
-    test_dir = "test_star_grch38"
+    test_dir = "temp_test_star_grch38"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_path = "./small_star.fastq"
     output_dir_path = f"./{test_dir}"
@@ -49,7 +49,7 @@ def test_star_grch38_parallel():
     """
     Tests STAR against the grch38 database, using parallel mode
     """
-    test_dir = "test_star_grch38_parallel"
+    test_dir = "temp_test_star_grch38_parallel"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_path = "./large_star.fastq"
     output_dir_path = f"./{test_dir}"
@@ -79,7 +79,7 @@ def test_star_grch38_dangerous_arg():
     """
     Tests STAR against the grch38 database, with a dangerous arg (changing functionality)
     """
-    test_dir = "test_star_grch38"
+    test_dir = "temp_test_star_grch38"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     input_file_path = "./small_star.fastq"
     output_dir_path = f"./{test_dir}"

--- a/tests/test_unicycler.py
+++ b/tests/test_unicycler.py
@@ -15,7 +15,7 @@ def test_unicycler():
     Tests Unicycler
     """
 
-    test_dir = "test_unicycler"
+    test_dir = "temp_test_unicycler"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}/"
 


### PR DESCRIPTION
Prefixes all integration tests with `temp_` and adds `temp_test_*` to the gitignore.