### PR TITLE
fix: async success in _check_thread_health

### DIFF
--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -301,11 +301,12 @@ class Tool:
         self._wait_for_threads_to_finish(check_health=False, wait_for_upload=False)
 
     def _check_thread_health(self):
-        """Checks for any thread that has ended without reaching a "complete" state, and propagates errors"""
+        """Checks for any thread that has ended without reaching a "success" state, and propagates errors"""
         for thread in self.query_threads:
             thread_name = thread.getName()
             thread_status = self.query_thread_statuses.get(thread_name)
-            if not thread.is_alive() and thread_status != ThreadStatus.COMPLETE:
+            success_status = ThreadStatus.EXECUTING if self.is_async else ThreadStatus.COMPLETE
+            if not thread.is_alive() and thread_status != success_status:
                 self._kill_query_threads()
                 raise ToolchestException("A job irrecoverably failed. See logs above for details.")
 


### PR DESCRIPTION
Updates the expected "success" status in `_check_thread_health()` to support async runs.