### PR TITLE
feat: add python3 tool implementation

### DIFF
--- a/tests/test_python3.py
+++ b/tests/test_python3.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+
+import toolchest_client as toolchest
+
+toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
+if toolchest_api_key:
+    toolchest.set_key(toolchest_api_key)
+
+
+@pytest.mark.integration
+def test_python3():
+    """
+    Tests python3 tool's inputs, output, and tool_arg
+    """
+
+    test_dir = "./temp_test_python3"
+    os.makedirs(f"{test_dir}", exist_ok=True)
+    toolchest.python3(
+        tool_args=f"./input/example.fastq",
+        script="s3://toolchest-integration-tests/write_test.py",
+        inputs="s3://toolchest-integration-tests/example.fastq",
+        output_path=f"{test_dir}/",
+    )
+
+    output_file = open(f"{test_dir}/output.txt", "r")
+    assert output_file.readline() == "Success"
+    output_file.close()

--- a/tests/test_python3.py
+++ b/tests/test_python3.py
@@ -17,7 +17,7 @@ def test_python3():
     test_dir = "./temp_test_python3"
     os.makedirs(f"{test_dir}", exist_ok=True)
     toolchest.python3(
-        tool_args=f"./input/example.fastq",
+        tool_args="./input/example.fastq",
         script="s3://toolchest-integration-tests/write_test.py",
         inputs="s3://toolchest-integration-tests/example.fastq",
         output_path=f"{test_dir}/",

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -32,8 +32,8 @@ from toolchest_client.api.query import Query
 from toolchest_client.api.status import Status, get_status
 from toolchest_client.api.urls import get_api_url, set_api_url
 from .tools.api import add_database, alphafold, bowtie2, cellranger_count, clustalo, demucs, diamond_blastp, \
-    diamond_blastx, kraken2, megahit, python3, rapsearch, rapsearch2, shi7, shogun_align, shogun_filter, STAR, test, unicycler, \
-    update_database
+    diamond_blastx, kraken2, megahit, python3, rapsearch, rapsearch2, shi7, shogun_align, shogun_filter, STAR, test, \
+    unicycler, update_database
 
 sentry_utils.MAX_STRING_LENGTH = 8192  # monkey patch for Sentry max message length
 sentry_sdk.init(

--- a/toolchest_client/__init__.py
+++ b/toolchest_client/__init__.py
@@ -32,7 +32,7 @@ from toolchest_client.api.query import Query
 from toolchest_client.api.status import Status, get_status
 from toolchest_client.api.urls import get_api_url, set_api_url
 from .tools.api import add_database, alphafold, bowtie2, cellranger_count, clustalo, demucs, diamond_blastp, \
-    diamond_blastx, kraken2, megahit, rapsearch, rapsearch2, shi7, shogun_align, shogun_filter, STAR, test, unicycler, \
+    diamond_blastx, kraken2, megahit, python3, rapsearch, rapsearch2, shi7, shogun_align, shogun_filter, STAR, test, unicycler, \
     update_database
 
 sentry_utils.MAX_STRING_LENGTH = 8192  # monkey patch for Sentry max message length

--- a/toolchest_client/tools/__init__.py
+++ b/toolchest_client/tools/__init__.py
@@ -7,6 +7,7 @@ from .demucs import Demucs
 from .diamond import DiamondBlastp, DiamondBlastx
 from .kraken2 import Kraken2
 from .megahit import Megahit
+from .python3 import Python3
 from .rapsearch2 import Rapsearch2
 from .shi7 import Shi7
 from .shogun import ShogunAlign, ShogunFilter

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -7,7 +7,6 @@ This module contains the API for using Toolchest tools.
 import os.path
 from datetime import date
 
-from toolchest_client import ToolchestException
 from toolchest_client.tools import AlphaFold, Bowtie2, CellRangerCount, ClustalO, Demucs, DiamondBlastp, DiamondBlastx,\
     Kraken2, Megahit, Python3, Rapsearch2, Shi7, ShogunAlign, ShogunFilter, STARInstance, Test, Unicycler
 
@@ -392,20 +391,23 @@ def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interl
 
 
 def python3(script, inputs=[], output_path=None, tool_args="", **kwargs):
-    """Runs Python3 via Toolchest.
-    NOTE: This tool is currently only available for customers with contracts
-    The script has a few requirements if inputs or outputs are expected. Inputs will be uploaded to `./input/` so the
-    script must use that prefix with hardcoded paths or when adding to tool_args to be parsed via sys.argv. Any output
-    that is expected to be returned needs to be stored at `./output/`. The directory will be compressed via pigz and
-    decompressed on the client.
+    """runs python3 via toolchest.
+    This a restricted tool. Reach out to us to request access.
+    inputs will be uploaded to `./input/` and can access by a call such as
+    `input_file = open("./input/your_file_name.type", "r")`
+    Any files that are expected to be returned need to be written or moved to the `./output/` directory such as
+    ```
+    f = open("./output/file.type", "a")
+    f.write("Output here")
+    f.close()
+    ```
 
-    :param script: Path to the python script to run
-    :param inputs: (optional) Path(s) to the input files to run with the python script. Will be uploaded to a directory
+    :param script: path to the python script to run
+    :param inputs: (optional) path(s) to the input files to run with the python script. will be uploaded to a directory
     `./input/` for use in the on the instance.
-    :param output_path: (optional) Local path to where the output file(s) will be downloaded.
-    :param tool_args: (optional) Additional arguments to be passed to Python3. Should NOT specify the script here but
-    any other args after the script should be included.
-    Usage::
+    :param output_path: (optional) local path to where the output file(s) will be downloaded.
+    :param tool_args: (optional) additional arguments to be passed to python3.
+    usage::
         >>> import toolchest_client as toolchest
         >>> toolchest.python3(
         ...     script="./path/to/script.py",
@@ -415,8 +417,6 @@ def python3(script, inputs=[], output_path=None, tool_args="", **kwargs):
     """
     if type(inputs) is str:
         inputs = [inputs]
-    elif type(inputs) is not list:
-        raise ToolchestException('Unknown input type')
     inputs.append(script)
     tool_args = f'./input/{os.path.basename(script)} {tool_args}'
     instance = Python3(

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -4,9 +4,10 @@ toolchest_client.tools.api
 
 This module contains the API for using Toolchest tools.
 """
+import os.path
 from datetime import date
 from toolchest_client.tools import AlphaFold, Bowtie2, CellRangerCount, ClustalO, Demucs, DiamondBlastp, DiamondBlastx,\
-    Kraken2, Megahit, Rapsearch2, Shi7, ShogunAlign, ShogunFilter, STARInstance, Test, Unicycler
+    Kraken2, Megahit, Python3, Rapsearch2, Shi7, ShogunAlign, ShogunFilter, STARInstance, Test, Unicycler
 
 
 def alphafold(inputs, output_path=None, model_preset=None, max_template_date=None, use_reduced_dbs=False,
@@ -381,6 +382,32 @@ def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interl
         tool_args=tool_args,
         input_prefix_mapping=input_prefix_mapping,
         inputs=input_list,
+        output_path=output_path,
+        **kwargs,
+    )
+    output = instance.run()
+    return output
+
+def python3(script, output_name, inputs=[], output_path=None, tool_args="", **kwargs):
+    """Runs Python3 via Toolchest.
+    :param script: Path to the python script to run
+    :param inputs: (optional) Path(s) to the input files  to run with the python script.
+    :param output_path: (optional) Base path to where the output file(s) will be downloaded.
+    :param tool_args: (optional) Additional arguments to be passed to Python3.
+    Usage::
+        >>> import toolchest_client as toolchest
+        >>> toolchest.python3(
+        ...     script="./path/to/script.py",
+        ...     output_path="./path/to/output/base",  # outputs
+        ...     tool_args="",
+        ... )
+    """
+    inputs.append(script)
+    tool_args = 'input/' + os.path.basename(script) + tool_args
+    instance = Python3(
+        tool_args=tool_args,
+        output_name=output_name,
+        inputs=inputs,
         output_path=output_path,
         **kwargs,
     )

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -391,27 +391,24 @@ def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interl
 
 
 def python3(script, inputs=[], output_path=None, tool_args="", **kwargs):
-    """runs python3 via toolchest.
-    This a restricted tool. Reach out to us to request access.
-    inputs will be uploaded to `./input/` and can access by a call such as
-    `input_file = open("./input/your_file_name.type", "r")`
-    Any files that are expected to be returned need to be written or moved to the `./output/` directory such as
-    ```
-    f = open("./output/file.type", "a")
-    f.write("Output here")
-    f.close()
-    ```
+    """Runs Python via Toolchest. This a restricted tool, running it requires you to request access.
 
-    :param script: path to the python script to run
-    :param inputs: (optional) path(s) to the input files to run with the python script. will be uploaded to a directory
-    `./input/` for use in the on the instance.
+    Within your Python3 script, input files are available at `./input/`.
+
+    Only output written to `./output/` is captured by Toolchest. Writing to other directories such as
+    `./temp/file.txt` is allowed. However, that file will not be captured and returned by Toolchest unless it's
+    written to `./output/file.txt` instead.
+
+    :param script: path to the Python script to run.
+    :param inputs: (optional) path(s) to the input files that will be accessible by your script at './input/'.
     :param output_path: (optional) local path to where the output file(s) will be downloaded.
-    :param tool_args: (optional) additional arguments to be passed to python3.
+    :param tool_args: (optional) additional arguments to be passed to your script as command line arguements.
     usage::
         >>> import toolchest_client as toolchest
         >>> toolchest.python3(
         ...     script="./path/to/script.py",
-        ...     output_path="./path/to/output/base",  # outputs
+        ...     inputs=["./path/to/input1.txt", "./path/to/input2.fastq"],
+        ...     output_path="./path/to/local/output/",
         ...     tool_args="",
         ... )
     """

--- a/toolchest_client/tools/python3.py
+++ b/toolchest_client/tools/python3.py
@@ -14,18 +14,16 @@ class Python3(Tool):
     """
     The Python3 implementation of the Tool class.
     """
-    def __init__(self, tool_args, output_name, inputs, output_path, **kwargs):
+    def __init__(self, tool_args, inputs, output_path, **kwargs):
         super().__init__(
             tool_name="python3",
             tool_version="3.9.1",
             tool_args=tool_args,
-            output_name=output_name,
             output_path=output_path,
             inputs=inputs,
             min_inputs=1,
             max_inputs=100,
             parallel_enabled=False,
-            output_type=OutputType.S3,
-            output_is_directory=False,
+            output_type=OutputType.GZ_TAR,
             **kwargs,
         )

--- a/toolchest_client/tools/python3.py
+++ b/toolchest_client/tools/python3.py
@@ -20,9 +20,6 @@ class Python3(Tool):
             tool_args=tool_args,
             output_path=output_path,
             inputs=inputs,
-            min_inputs=1,
-            max_inputs=100,
-            parallel_enabled=False,
             output_type=OutputType.GZ_TAR,
             **kwargs,
         )

--- a/toolchest_client/tools/python3.py
+++ b/toolchest_client/tools/python3.py
@@ -1,10 +1,9 @@
 """
-toolchest_client.tools.test
+toolchest_client.tools.python3
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is the test implementation of the Tool class.
+This is the Python3 implementation of the Tool class.
 """
-import os
 from toolchest_client.files import OutputType
 
 from . import Tool

--- a/toolchest_client/tools/python3.py
+++ b/toolchest_client/tools/python3.py
@@ -1,0 +1,31 @@
+"""
+toolchest_client.tools.test
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is the test implementation of the Tool class.
+"""
+import os
+from toolchest_client.files import OutputType
+
+from . import Tool
+
+
+class Python3(Tool):
+    """
+    The Python3 implementation of the Tool class.
+    """
+    def __init__(self, tool_args, output_name, inputs, output_path, **kwargs):
+        super().__init__(
+            tool_name="python3",
+            tool_version="3.9.1",
+            tool_args=tool_args,
+            output_name=output_name,
+            output_path=output_path,
+            inputs=inputs,
+            min_inputs=1,
+            max_inputs=100,
+            parallel_enabled=False,
+            output_type=OutputType.S3,
+            output_is_directory=False,
+            **kwargs,
+        )

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -125,6 +125,9 @@ class Tool:
         dangerlist = TOOL_ARG_LISTS[self.tool_name].get("dangerlist", [])  # some tools have a dangerlist
         blacklist = TOOL_ARG_LISTS[self.tool_name].get("blacklist", [])  # some tools have a blacklist
 
+        if (len(whitelist.keys()) == 1 and "*" in whitelist.keys()):
+            return
+
         sanitized_args = []  # arguments that are explicitly allowed
         unknown_args = []  # all arguments that were not included
         blacklisted_args = []  # arguments that are known to not work

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -125,9 +125,6 @@ class Tool:
         dangerlist = TOOL_ARG_LISTS[self.tool_name].get("dangerlist", [])  # some tools have a dangerlist
         blacklist = TOOL_ARG_LISTS[self.tool_name].get("blacklist", [])  # some tools have a blacklist
 
-        if (len(whitelist.keys()) == 1 and "*" in whitelist.keys()):
-            return
-
         sanitized_args = []  # arguments that are explicitly allowed
         unknown_args = []  # all arguments that were not included
         blacklisted_args = []  # arguments that are known to not work
@@ -168,7 +165,7 @@ class Tool:
                 else:
                     unknown_args.append(arg)
 
-        if unknown_args or blacklisted_args:
+        if blacklisted_args or (unknown_args and not (len(whitelist.keys()) == 1 and "*" in whitelist.keys())):
             print("Non-allowed arguments found in tool_args:")
             print(
                 f"Blacklisted arguments (these are known to cause Toolchest to fail): \
@@ -179,6 +176,10 @@ class Tool:
 {unknown_args if unknown_args else '(none)'}"
             )
             raise ValueError("Unknown or blacklisted arguments present in tool_args. See above for details.")
+
+        # Don't change tool args with * whitelist in order to preserve ordering
+        if len(whitelist.keys()) == 1 and "*" in whitelist.keys():
+            return
 
         if dangerous_args:
             print("WARNING: dangerous arguments found in tool_args. This disables validation and parallelization!")

--- a/toolchest_client/tools/tool_args.py
+++ b/toolchest_client/tools/tool_args.py
@@ -385,6 +385,11 @@ TOOL_ARG_LISTS = {
             "--min-contig-len": 1,
         },
     },
+    "python3": {
+        "whitelist": {
+            "*": VARIABLE_ARGS
+        }
+    },
     "rapsearch2": {
         "blacklist": [
             "-q",

--- a/toolchest_client/tools/tool_args.py
+++ b/toolchest_client/tools/tool_args.py
@@ -387,8 +387,14 @@ TOOL_ARG_LISTS = {
     },
     "python3": {
         "whitelist": {
-            "*": VARIABLE_ARGS
-        }
+            # This allows all args that are not in the blacklist if this is the only whitelisted arg
+            "*": 0
+        },
+        "blacklist": [  # Toolchest only allows non-interactive script execution
+            '-i',
+            '-c',
+            '-m'
+        ]
     },
     "rapsearch2": {
         "blacklist": [


### PR DESCRIPTION
Implements a tool to run python3 scripts via Toolchest. Script must use the expected local input and output directories but are otherwise not limited.