### PR TITLE
fix: add default distributed value at tool level to fix add database

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.9.22"
+version = "0.9.23"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/tests/test_database_update.py
+++ b/tests/test_database_update.py
@@ -27,7 +27,7 @@ def test_database_update_s3():
 @pytest.mark.integration
 def test_database_update_local():
     """
-    Tests custom database update for diamond blastp using a local file
+    Tests custom database update for diamond blastx using a local file
     """
     test_dir = "temp_test_database_update_local"
     os.makedirs(f"./{test_dir}", exist_ok=True)
@@ -39,7 +39,7 @@ def test_database_update_local():
 
     output = toolchest.update_database(
         database_path=test_dir,
-        tool=toolchest.tools.Kraken2,
+        tool=toolchest.tools.DiamondBlastx,
         database_name="standard",
     )
 

--- a/toolchest_client/tools/diamond.py
+++ b/toolchest_client/tools/diamond.py
@@ -34,7 +34,7 @@ class DiamondBlastx(Tool):
     The DIAMOND BLASTX implementation of the Tool class.
     """
     def __init__(self, inputs,  database_name, database_version, output_path, output_primary_name, tool_args,
-                 distributed, **kwargs):
+                 distributed=False, **kwargs):
         super().__init__(
             tool_name="diamond_blastx" if not distributed else "diamond_blastx_parallel",
             tool_version="2.0.13",


### PR DESCRIPTION
Add and update database functions instantiate tools directly so any non-standard args without defaults at the tool level break those functions for that tool. This happened with the new `distributed` arg for diamond blastx so this pr adds the same default as the `api.py` function to the tool itself.  