### PR TITLE
fix: add dash in front of task arg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.9.24"
+version = "0.9.25"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/tests/test_blastn.py
+++ b/tests/test_blastn.py
@@ -27,3 +27,22 @@ def test_blastn_nt():
     )
 
     assert hash.unordered(output_file_path) == 1290536116
+
+
+@pytest.mark.integration
+def test_blastn_nt_task_blastn():
+    """
+    Tests BLASTN against the default nt (v1) DB
+    """
+    test_dir = "temp_test_blastn_nt"
+    os.makedirs(f"./{test_dir}", exist_ok=True)
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/blastn_results.out"
+
+    toolchest.blastn(
+        inputs="s3://toolchest-integration-tests/small_synthetic_bacteroides_reads.fasta",
+        output_path=output_dir_path,
+        tool_args="-mt_mode 1 -task blastn"
+    )
+
+    assert hash.unordered(output_file_path) == 1657058660

--- a/toolchest_client/tools/tool_args.py
+++ b/toolchest_client/tools/tool_args.py
@@ -94,7 +94,7 @@ TOOL_ARG_LISTS = {
             "-ungapped": 0,
             "-window_size": 1,
             "-mt_mode": 1,
-            "task": 1,
+            "-task": 1,
         },
     },
     "bowtie2": {


### PR DESCRIPTION
Not sure why this worked locally but adding the dash and an integration test for the task arg.