### PR TITLE
fix: skip head request for presigned s3 urls

### DIFF
--- a/tests/test_public_uri.py
+++ b/tests/test_public_uri.py
@@ -9,7 +9,7 @@ if toolchest_api_key:
 
 
 @pytest.mark.integration
-def test_http_input():
+def test_s3_http_input():
     """
     Tests test function with an http input
     """
@@ -26,6 +26,24 @@ def test_http_input():
 
     with open(output_file_path, "r") as f:
         assert f.read().strip() == "success"
+
+
+@pytest.mark.integration
+def test_http_input():
+    """
+    Tests transfer function with an http input
+    """
+    test_dir = "temp_test_ftp"
+    os.makedirs(f"./{test_dir}", exist_ok=True)
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/P48754.fasta"
+
+    toolchest.transfer(
+        inputs="https://rest.uniprot.org/uniprotkb/P48754.fasta",
+        output_path=output_dir_path
+    )
+
+    assert os.path.getsize(output_file_path) == 1962
 
 
 @pytest.mark.integration

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -217,6 +217,8 @@ class Query:
             'input-files'
         ])
         file_name = os.path.basename(input_file_path)
+        if "?" in file_name:
+            file_name = file_name.split("?")[0]
         input_is_in_s3 = path_is_s3_uri(input_file_path)
         input_is_http_url = path_is_http_url(input_file_path)
         input_is_ftp_url = path_is_accessible_ftp_url(input_file_path)

--- a/toolchest_client/files/public_uris.py
+++ b/toolchest_client/files/public_uris.py
@@ -4,7 +4,6 @@ toolchest_client.files.public_uris
 
 Functions for handling files given by HTTP / HTTPS / FTP URIs.
 """
-import os
 from ftplib import FTP
 from urllib.parse import urlparse
 from urllib3.exceptions import LocationParseError
@@ -53,7 +52,7 @@ def get_http_url_file_size(url):
 
     :param url: An input URL.
     """
-    if all([x in url for x in["https://", "s3", "amazonaws.com"]]):
+    if all([x in url for x in ["https://", "s3", "amazonaws.com"]]):
         return 0
     response = requests.head(url)
     response.raise_for_status()

--- a/toolchest_client/files/public_uris.py
+++ b/toolchest_client/files/public_uris.py
@@ -4,6 +4,7 @@ toolchest_client.files.public_uris
 
 Functions for handling files given by HTTP / HTTPS / FTP URIs.
 """
+import os
 from ftplib import FTP
 from urllib.parse import urlparse
 from urllib3.exceptions import LocationParseError
@@ -52,6 +53,8 @@ def get_http_url_file_size(url):
 
     :param url: An input URL.
     """
+    if all([x in url for x in["https://", "s3", "amazonaws.com"]]):
+        return 0
     response = requests.head(url)
     response.raise_for_status()
     return int(response.headers.get('content-length', 0))


### PR DESCRIPTION
S3 URLs don't allow head requests to get content-size prior to download