### PR TITLE
fix: bowtie2 tests

### DIFF
--- a/tests/test_bowtie2.py
+++ b/tests/test_bowtie2.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 
+from tests.util import filter_output, hash
 import toolchest_client as toolchest
 
 toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
@@ -17,11 +18,14 @@ def test_bowtie2():
     test_dir = "temp_test_bowtie2_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}/"
+    output_file_path = f"{output_dir_path}bowtie2_output.sam"
+    filtered_output_file_path = f"{output_dir_path}bowtie2_output.filtered.sam"
 
     toolchest.bowtie2(
         inputs="s3://toolchest-integration-tests/DRR000006.fastq.gz",
         output_path=output_dir_path,
     )
 
-    # Bowtie2 hash is non-deterministic but size is consistent between runs
-    assert os.path.getsize(f"{output_dir_path}bowtie2_output.sam") == 1043855350
+    # Filter non-deterministic metadata lines
+    filter_output.filter_sam(output_file_path, filtered_output_file_path)
+    assert hash.unordered(filtered_output_file_path) == 1444969892

--- a/tests/test_bowtie2.py
+++ b/tests/test_bowtie2.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from tests.util import filter_output, hash
+from tests.util import hash, filter_output
 import toolchest_client as toolchest
 
 toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
@@ -17,9 +17,9 @@ def test_bowtie2():
 
     test_dir = "temp_test_bowtie2_standard"
     os.makedirs(f"./{test_dir}", exist_ok=True)
-    output_dir_path = f"./{test_dir}/"
-    output_file_path = f"{output_dir_path}bowtie2_output.sam"
-    filtered_output_file_path = f"{output_dir_path}bowtie2_output.filtered.sam"
+    output_dir_path = f"./{test_dir}"
+    output_file_path = f"{output_dir_path}/bowtie2_output.sam"
+    filtered_output_file_path = f"{output_dir_path}/bowtie2_output.filtered.sam"
 
     toolchest.bowtie2(
         inputs="s3://toolchest-integration-tests/DRR000006.fastq.gz",

--- a/tests/test_database_update.py
+++ b/tests/test_database_update.py
@@ -2,7 +2,7 @@ import os
 import time
 import pytest
 
-from tests.util import s3, hash
+from tests.util import s3, hash, filter_output
 import toolchest_client as toolchest
 
 toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
@@ -19,6 +19,7 @@ def test_database_update_s3():
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
     output_file_path = f"{output_dir_path}/bowtie2_output.sam"
+    filtered_output_file_path = f"{output_dir_path}/bowtie2_output.filtered.sam"
 
     # Update DB
     update_db_output = toolchest.update_database(
@@ -45,7 +46,8 @@ def test_database_update_s3():
         database_name=update_db_output.database_name,
         database_version=update_db_output.database_version,
     )
-    assert os.path.getsize(output_file_path) == 64914832
+    filter_output.filter_sam(output_file_path, filtered_output_file_path)
+    assert hash.unordered(filtered_output_file_path) == 107700257
 
 
 @pytest.mark.integration
@@ -65,6 +67,7 @@ def test_database_update_local():
     ]
     output_dir_path = f"./{test_dir}"
     output_file_path = f"{output_dir_path}/bowtie2_output.sam"
+    filtered_output_file_path = f"{output_dir_path}/bowtie2_output.filtered.sam"
     os.makedirs(input_dir_path, exist_ok=True)
 
     # Download DB files
@@ -92,7 +95,9 @@ def test_database_update_local():
         database_name=update_db_output.database_name,
         database_version=update_db_output.database_version,
     )
-    assert os.path.getsize(output_file_path) == 62764495
+
+    filter_output.filter_sam(output_file_path, filtered_output_file_path)
+    assert hash.unordered(filtered_output_file_path) == 1936736537
 
 
 @pytest.mark.integration

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from tests.util import s3, hash
+from tests.util import s3, hash, filter_output
 import toolchest_client as toolchest
 
 toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
@@ -37,9 +37,7 @@ def test_star_grch38():
     assert 185952700 <= os.path.getsize(output_file_path) <= 185952900  # expected size 185952796
 
     # Filter non-deterministic metadata lines
-    with open(filtered_output_file_path, "w") as outfile:
-        with open(output_file_path, "r") as infile:
-            outfile.writelines([line for line in infile if not line.startswith("@PG") and not line.startswith("@CO")])
+    filter_output.filter_sam(output_file_path, filtered_output_file_path)
     assert hash.unordered(filtered_output_file_path) == 2099424598
 
 

--- a/tests/util/filter_output.py
+++ b/tests/util/filter_output.py
@@ -1,0 +1,7 @@
+def filter_sam(unfiltered_path, filtered_path):
+    """
+    Filters out non-deterministic metadata lines from a SAM output file.
+    """
+    with open(filtered_path, "w") as outfile:
+        with open(unfiltered_path, "r") as infile:
+            outfile.writelines([line for line in infile if not line.startswith("@PG") and not line.startswith("@CO")])


### PR DESCRIPTION
Fixes `bowtie2`-based tests by testing actual output values instead of a filesize check. 

New tests filter out non-deterministic metadata lines from the output SAM file and then hash the rest of the content, which is deterministic.