### PR TITLE
feat: add capability for a user to request what instance type to run on

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.9.27"
+version = "0.9.28"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bcai@trytoolchest.com>",

--- a/tests/test_python3.py
+++ b/tests/test_python3.py
@@ -5,6 +5,7 @@ import docker
 import pytest
 
 import toolchest_client as toolchest
+from toolchest_client.api.instance_type import InstanceType
 
 toolchest_api_key = os.environ.get("TOOLCHEST_API_KEY")
 if toolchest_api_key:
@@ -26,6 +27,7 @@ def test_python3():
         script="s3://toolchest-integration-tests/write_test.py",
         inputs="s3://toolchest-integration-tests/example.fastq",
         output_path=f"{test_dir}/",
+        instance_type=InstanceType.COMPUTE_2
     )
 
     output_file = open(f"{test_dir}/output.txt", "r")
@@ -53,7 +55,8 @@ def test_python3_with_docker():
     toolchest.python3(
         script="s3://toolchest-integration-tests/numpy_test.py",
         output_path=f"{test_dir}/",
-        custom_docker_image_id="python3-numpy:3.9"
+        custom_docker_image_id="python3-numpy:3.9",
+        instance_type="compute-2",
     )
 
     output_file = open(f"{test_dir}/output.txt", "r")

--- a/toolchest_client/api/instance_type.py
+++ b/toolchest_client/api/instance_type.py
@@ -28,6 +28,3 @@ class InstanceType(Enum):
     MEMORY_256 = "memory-256"
     MEMORY_384 = "memory-384"
     MEMORY_512 = "memory-512"
-
-
-

--- a/toolchest_client/api/instance_type.py
+++ b/toolchest_client/api/instance_type.py
@@ -1,0 +1,33 @@
+from enum import Enum
+
+
+class InstanceType(Enum):
+    # Compute optimized, lists vCPUs, 1:2 vCPU to RAM ratio
+    COMPUTE_2 = "compute-2"
+    COMPUTE_4 = "compute-4"
+    COMPUTE_8 = "compute-8"
+    COMPUTE_16 = "compute-16"
+    COMPUTE_32 = "compute-32"
+    COMPUTE_48 = "compute-48"
+    COMPUTE_64 = "compute-64"
+    COMPUTE_96 = "compute-96"
+    # General optimized, lists vCPUs, 1:4 vCPU to RAM ratio
+    GENERAL_2 = "general-2"
+    GENERAL_4 = "general-4"
+    GENERAL_8 = "general-8"
+    GENERAL_16 = "general-16"
+    GENERAL_32 = "general-32"
+    GENERAL_48 = "general-48"
+    GENERAL_64 = "general-64"
+    GENERAL_96 = "general-96"
+    # Memory optimized, lists memory, 1:8 vCPU to RAM ratio
+    MEMORY_16 = "memory-16"
+    MEMORY_32 = "memory-32"
+    MEMORY_64 = "memory-64"
+    MEMORY_128 = "memory-128"
+    MEMORY_256 = "memory-256"
+    MEMORY_384 = "memory-384"
+    MEMORY_512 = "memory-512"
+
+
+

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -78,7 +78,7 @@ class Query:
                   output_type, tool_args=None, database_name=None, database_version=None,
                   custom_database_path=None, input_files=None, is_database_update=False,
                   database_primary_name=None, output_path=None, output_primary_name=None,
-                  skip_decompression=False, thread_statuses=None, custom_docker_image_id=None, 
+                  skip_decompression=False, thread_statuses=None, custom_docker_image_id=None,
                   instance_type=None, volume_size=None):
         """Executes a query to the Toolchest API.
 

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -476,7 +476,7 @@ def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interl
 
 
 def python3(script, inputs=None, output_path=None, tool_args="", custom_docker_image_id=None,
-            instance_type=InstanceType.COMPUTE_32, volume_size=8, **kwargs):
+            instance_type=InstanceType.COMPUTE_2, volume_size=8, **kwargs):
     """Runs Python via Toolchest. This a restricted tool, running it requires you to request access.
 
     Within your Python3 script, input files are available at `./input/`.

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -8,6 +8,7 @@ import os.path
 from datetime import date
 
 from toolchest_client.api.exceptions import ToolchestException
+from toolchest_client.api.instance_type import InstanceType
 from toolchest_client.files import path_is_s3_uri
 from toolchest_client.tools import AlphaFold, BLASTN, Bowtie2, CellRangerCount, ClustalO, Demucs, DiamondBlastp,\
     DiamondBlastx, HUMAnN3, Kraken2, Megahit, Python3, Rapsearch2, Shi7, ShogunAlign, ShogunFilter, STARInstance,\
@@ -43,6 +44,8 @@ def alphafold(inputs, output_path=None, model_preset=None, max_template_date=Non
         ... )
 
     """
+    if 'instance_type' in kwargs:
+        raise ToolchestException("Argument 'instance_type' is not supported by Alphafold currently.")
     tool_args = (
         (f"--model_preset={model_preset} " if model_preset is not None else "") +
         (f"--max_template_date={max_template_date} " if max_template_date is not None
@@ -216,6 +219,8 @@ def demucs(inputs, output_path=None, tool_args="", **kwargs):
         ... )
 
     """
+    if 'instance_type' in kwargs:
+        raise ToolchestException("Argument 'instance_type' is not supported by Demucs currently.")
 
     instance = Demucs(
         tool_args=tool_args,
@@ -470,7 +475,8 @@ def megahit(output_path=None, tool_args="", read_one=None, read_two=None, interl
     return output
 
 
-def python3(script, inputs=[], output_path=None, tool_args="", custom_docker_image_id=None, **kwargs):
+def python3(script, inputs=None, output_path=None, tool_args="", custom_docker_image_id=None,
+            instance_type=InstanceType.COMPUTE_32, volume_size=8, **kwargs):
     """Runs Python via Toolchest. This a restricted tool, running it requires you to request access.
 
     Within your Python3 script, input files are available at `./input/`.
@@ -483,8 +489,11 @@ def python3(script, inputs=[], output_path=None, tool_args="", custom_docker_ima
     :param inputs: (optional) path(s) to the input files that will be accessible by your script at './input/'.
     :param output_path: (optional) local path to where the output file(s) will be downloaded.
     :param tool_args: (optional) additional arguments to be passed to your script as command line arguements.
-    :param custom_docker_image: (optional) a tagged docker image to be used as an execution environment that can provide
-    dependencies for the script.
+    :param custom_docker_image_id: (optional) a tagged docker image to be used as an execution environment that can
+    provide dependencies for the script.
+    :param instance_type: (optional) allows you to select the instance that best fits the resources required for your
+    script. Can accept the InstanceType enum or the underlying string (i.e. InstanceType.GENERAL_2 or "general-2").
+    :param volume_size: (optional) allows you to set the amount of storage needed for your script.
     usage::
         >>> import toolchest_client as toolchest
         >>> toolchest.python3(
@@ -494,6 +503,8 @@ def python3(script, inputs=[], output_path=None, tool_args="", custom_docker_ima
         ...     tool_args="",
         ... )
     """
+    if inputs is None:
+        inputs = []
     if type(inputs) is str:
         inputs = [inputs]
     inputs.append(script)
@@ -503,6 +514,8 @@ def python3(script, inputs=[], output_path=None, tool_args="", custom_docker_ima
         inputs=inputs,
         output_path=output_path,
         custom_docker_image_id=custom_docker_image_id,
+        instance_type=instance_type,
+        volume_size=volume_size,
         **kwargs,
     )
     output = instance.run()
@@ -742,6 +755,8 @@ def transfer(inputs, output_path=None, **kwargs):
         ... )
 
     """
+    if 'instance_type' in kwargs:
+        raise ToolchestException("Argument 'instance_type' is not supported by transfer currently.")
 
     if isinstance(inputs, list):
         if not path_is_s3_uri(output_path):

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -40,7 +40,8 @@ class Tool:
                  group_paired_ends=False, compress_inputs=False,
                  output_type=OutputType.FLAT_TEXT, expected_output_file_names=None,
                  is_async=False, is_database_update=False,
-                 skip_decompression=False, custom_docker_image_id=None):
+                 skip_decompression=False, custom_docker_image_id=None,
+                 instance_type=None, volume_size=None):
         self.tool_name = tool_name
         self.tool_version = tool_version
         self.tool_args = tool_args
@@ -81,6 +82,8 @@ class Tool:
         self.is_database_update = is_database_update
         self.skip_decompression = skip_decompression
         self.custom_docker_image_id = custom_docker_image_id
+        self.instance_type = instance_type
+        self.volume_size = volume_size
         signal.signal(signal.SIGTERM, self._handle_termination)
         signal.signal(signal.SIGINT, self._handle_termination)
 
@@ -455,6 +458,7 @@ class Tool:
                 "database_version": self.database_version,
                 "input_files": input_files,
                 "input_prefix_mapping": self.input_prefix_mapping,
+                "instance_type": self.instance_type,
                 "is_database_update": self.is_database_update,
                 "output_path": temp_parallel_output_file_path if should_run_in_parallel else non_parallel_output_path,
                 "output_primary_name": self.output_primary_name,
@@ -463,6 +467,7 @@ class Tool:
                 "tool_name": self.tool_name,
                 "tool_version": self.tool_version,
                 "tool_args": self.tool_args,
+                "volume_size": self.volume_size
             })
 
             # Add non-distinct dictionary for status updates


### PR DESCRIPTION
Adds `instance_type` and `volume_size` args to tool to allow users more flexibility in their runs. The args are top level args for python3 as the workloads for python3 are much more variable. The args are accessible via `**kwargs` for all other tools except AlphaFold, Demucs, and Transfer, which do not allow changing instance type.