### PR TITLE
fix: filter date out of fastqc output for hashing

### DIFF
--- a/tests/test_fastqc.py
+++ b/tests/test_fastqc.py
@@ -29,7 +29,7 @@ def test_fastqc():
         os.path.join(test_dir, "sample_r1_shortened_fastqc.html"),
         filtered_html_output_path,
         search_regex='id="header_filename">([\\w\\s]+)<br',
-        replacement_str='id="header_filename">)<br'
+        replacement_str='id="header_filename"><br'
     )
-    assert hash.unordered(filtered_html_output_path) == 730605983
+    assert hash.unordered(filtered_html_output_path) == 816103024
     assert 325000 <= os.path.getsize(os.path.join(test_dir, "sample_r1_shortened_fastqc.zip")) <= 327000

--- a/tests/util/filter_output.py
+++ b/tests/util/filter_output.py
@@ -1,3 +1,6 @@
+import re
+
+
 def filter_sam(unfiltered_path, filtered_path):
     """
     Filters out non-deterministic metadata lines from a SAM output file.
@@ -5,3 +8,13 @@ def filter_sam(unfiltered_path, filtered_path):
     with open(filtered_path, "w") as outfile:
         with open(unfiltered_path, "r") as infile:
             outfile.writelines([line for line in infile if not line.startswith("@PG") and not line.startswith("@CO")])
+
+
+def filter_regex(unfiltered_path, filtered_path, search_regex, replacement_str):
+    """
+    Filters out non-deterministic metadata lines from a SAM output file.
+    """
+    with open(filtered_path, "w") as outfile:
+        with open(unfiltered_path, "r") as infile:
+            for line in infile:
+                outfile.write(re.sub(search_regex, replacement_str, line))


### PR DESCRIPTION
Removes the date from FastQC html output via regex as that is the only non-deterministic part of the html.