### PR TITLE
feat: S3 prefix input handling for custom DB updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
   integration-tests:
     executor: python/default
     working_directory: ~/repo
-    parallelism: 4
+    parallelism: 8
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: |
             cd ~/repo
             poetry install
-            poetry run pytest -v -m "not (integration or integration_part or integration_full)"
+            poetry run pytest -v -m "not (integration or integration_full)"
   integration-tests:
     executor: python/default
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: |
             cd ~/repo
             poetry install
-            poetry run pytest -v -m "not (integration or integration_full)"
+            poetry run pytest -v -m "not (integration or integration_part or integration_full)"
   integration-tests:
     executor: python/default
     working_directory: ~/repo

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
 markers =
     integration: mark a test as an integration test.
-    integration_part: mark a test as a component of a larger test.
     integration_full: mark a test as a full-suite integration test (only run on pre-deploy).
 junit_family=xunit1

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
     integration: mark a test as an integration test.
+    integration_part: mark a test as a component of a larger test.
     integration_full: mark a test as a full-suite integration test (only run on pre-deploy).
 junit_family=xunit1

--- a/tests/test_database_update.py
+++ b/tests/test_database_update.py
@@ -10,7 +10,7 @@ if toolchest_api_key:
     toolchest.set_key(toolchest_api_key)
 
 
-@pytest.mark.integration
+@pytest.mark.integration_part
 def test_database_update_s3():
     """
     Tests custom database update for bowtie 2 using S3 files
@@ -50,7 +50,7 @@ def test_database_update_s3():
     assert hash.unordered(filtered_output_file_path) == 107700257
 
 
-@pytest.mark.integration
+@pytest.mark.integration_part
 def test_database_update_s3_prefix():
     """
     Tests custom database update for bowtie 2 using an S3 prefix and assumed primary name

--- a/tests/test_database_update.py
+++ b/tests/test_database_update.py
@@ -53,8 +53,11 @@ def test_database_update_s3():
 @pytest.mark.integration
 def test_database_update_s3_prefix():
     """
-        Tests custom database update for bowtie 2 using an S3 prefix
-        """
+    Tests custom database update for bowtie 2 using an S3 prefix and assumed primary name
+
+    NOTE: to test auto-generation of database_primary_name, this should be run right after
+    test_database_update_s3
+    """
     test_dir = "temp_test_db_update_s3_prefix_bowtie2"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
@@ -62,11 +65,11 @@ def test_database_update_s3_prefix():
     filtered_output_file_path = f"{output_dir_path}/bowtie2_output.filtered.sam"
 
     # Update DB
+    # This should be the same Dmel_A4_1.0 database as test_database_update_s3()
     update_db_output = toolchest.update_database(
         database_path="s3://toolchest-public-examples-no-encryption/integration-test-db/bowtie2-fruitfly",
         tool=toolchest.tools.Bowtie2,
         database_name="integration_test_bowtie2_fruitfly",
-        database_primary_name="Dmel_A4_1.0",
         is_async=False,  # to ensure DB finishes uploading before tool call
     )
     assert update_db_output.database_name == "integration_test_bowtie2_fruitfly"
@@ -164,6 +167,7 @@ def test_database_add_s3():
         tool=toolchest.tools.Kraken2,
         database_name=f"integration_test_kraken2_viral_{time.time()}",
         is_async=False,  # to ensure DB finishes uploading before tool call
+        database_primary_name=None,
     )
     assert add_db_output.database_name.startswith("integration_test_kraken2_viral")
     assert add_db_output.database_version == "1"

--- a/tests/test_database_update.py
+++ b/tests/test_database_update.py
@@ -55,7 +55,7 @@ def test_database_update_s3_prefix():
     """
         Tests custom database update for bowtie 2 using an S3 prefix
         """
-    test_dir = "temp_test_db_update_s3_bowtie2"
+    test_dir = "temp_test_db_update_s3_prefix_bowtie2"
     os.makedirs(f"./{test_dir}", exist_ok=True)
     output_dir_path = f"./{test_dir}"
     output_file_path = f"{output_dir_path}/bowtie2_output.sam"

--- a/tests/test_database_update.py
+++ b/tests/test_database_update.py
@@ -11,18 +11,44 @@ if toolchest_api_key:
 
 
 @pytest.mark.integration
-def test_database_update_s3():
+def test_database_add_and_update_s3():
     """
-    Tests custom database update for bowtie 2 using S3 files.
-    Runs 2 update tests in sequence. The second part tests using
-    an S3 prefix and auto-generated primary name.
+    Tests custom database add and update for bowtie 2 using S3 files.
+    The update test assumes the database primary name from the add test.
     """
-    # Part 1: test using explicitly listed files and primary name
-    listed_files_test_dir = "temp_test_db_update_s3_bowtie2"
-    os.makedirs(f"./{listed_files_test_dir}", exist_ok=True)
-    output_dir_path = f"./{listed_files_test_dir}"
+    add_test_dir = "temp_test_db_add_s3_bowtie2"
+    os.makedirs(f"./{add_test_dir}", exist_ok=True)
+    output_dir_path = f"./{add_test_dir}"
 
-    # Update DB
+    # Part 1: add DB
+    add_db_output = toolchest.add_database(
+        database_path=[
+            "s3://toolchest-integration-tests/databases/bowtie2-fruitfly-Dmel/Dmel_A4_1.0.1.bt2",
+            "s3://toolchest-integration-tests/databases/bowtie2-fruitfly-Dmel/Dmel_A4_1.0.2.bt2",
+            "s3://toolchest-integration-tests/databases/bowtie2-fruitfly-Dmel/Dmel_A4_1.0.3.bt2",
+            "s3://toolchest-integration-tests/databases/bowtie2-fruitfly-Dmel/Dmel_A4_1.0.4.bt2",
+            "s3://toolchest-integration-tests/databases/bowtie2-fruitfly-Dmel/Dmel_A4_1.0.rev.1.bt2",
+            "s3://toolchest-integration-tests/databases/bowtie2-fruitfly-Dmel/Dmel_A4_1.0.rev.2.bt2",
+        ],
+        tool=toolchest.tools.Bowtie2,
+        database_name=f"integration_test_bowtie2_fruitfly_{time.time()}",
+        database_primary_name="Dmel_A4_1.0",
+        is_async=False,  # to ensure DB finishes uploading before tool call
+    )
+    assert add_db_output.database_name.startswith("integration_test_bowtie2_fruitfly")
+    assert add_db_output.database_version == "1"
+
+    run_and_test_bowtie2_on_updated_db(
+        expected_hash=107700257,
+        output_dir_path=output_dir_path,
+        toolchest_output=add_db_output,
+    )
+
+    # Part 2: update DB using an assumed primary name
+    update_test_dir = "temp_test_db_update_s3_bowtie2"
+    os.makedirs(f"./{update_test_dir}", exist_ok=True)
+    output_dir_path = f"./{update_test_dir}"
+
     update_db_output = toolchest.update_database(
         database_path=[
             "s3://toolchest-integration-tests/databases/bowtie2-fruitfly-Dmel/Dmel_A4_1.0.1.bt2",
@@ -33,39 +59,16 @@ def test_database_update_s3():
             "s3://toolchest-integration-tests/databases/bowtie2-fruitfly-Dmel/Dmel_A4_1.0.rev.2.bt2",
         ],
         tool=toolchest.tools.Bowtie2,
-        database_name="integration_test_bowtie2_fruitfly",
-        database_primary_name="Dmel_A4_1.0",
+        database_name=add_db_output.database_name,
         is_async=False,  # to ensure DB finishes uploading before tool call
     )
-    assert update_db_output.database_name == "integration_test_bowtie2_fruitfly"
-    assert update_db_output.database_version
+    assert update_db_output.database_name == add_db_output.database_name
+    assert update_db_output.database_version == "2"
 
     run_and_test_bowtie2_on_updated_db(
         expected_hash=107700257,
         output_dir_path=output_dir_path,
-        update_db_output=update_db_output
-    )
-
-    # Part 2: test using an S3 prefix and assumed primary name
-    prefix_test_dir = "temp_test_db_update_s3_prefix_bowtie2"
-    os.makedirs(f"./{prefix_test_dir}", exist_ok=True)
-    output_dir_path = f"./{prefix_test_dir}"
-
-    # Update DB
-    # This should be the same Dmel_A4_1.0 database
-    update_db_output = toolchest.update_database(
-        database_path="s3://toolchest-public-examples-no-encryption/integration-test-db/bowtie2-fruitfly",
-        tool=toolchest.tools.Bowtie2,
-        database_name="integration_test_bowtie2_fruitfly",
-        is_async=False,  # to ensure DB finishes uploading before tool call
-    )
-    assert update_db_output.database_name == "integration_test_bowtie2_fruitfly"
-    assert update_db_output.database_version
-
-    run_and_test_bowtie2_on_updated_db(
-        expected_hash=107700257,
-        output_dir_path=output_dir_path,
-        update_db_output=update_db_output
+        toolchest_output=update_db_output,
     )
 
 
@@ -109,21 +112,19 @@ def test_database_update_local():
     run_and_test_bowtie2_on_updated_db(
         expected_hash=1936736537,
         output_dir_path=output_dir_path,
-        update_db_output=update_db_output
+        toolchest_output=update_db_output
     )
 
 
 @pytest.mark.integration
-def test_database_add_s3():
+def test_database_add_s3_prefix():
     """
-    Tests custom database addition for Kraken 2
+    Tests custom database addition for Kraken 2, using an S3 prefix.
     """
     KRAKEN2_OUTPUT_VIRAL_HASH = 1003212151
 
     test_dir = "temp_test_db_add_kraken2_viral"
     os.makedirs(f"./{test_dir}", exist_ok=True)
-    output_dir_path = f"./{test_dir}"
-    output_file_path = f"{output_dir_path}/kraken2_output.txt"
 
     # Add database
     add_db_output = toolchest.add_database(
@@ -141,15 +142,16 @@ def test_database_add_s3():
         read_one="s3://toolchest-integration-tests/synthetic_bacteroides_reads.fasta",
         database_name=add_db_output.database_name,
         database_version=add_db_output.database_version,
-        output_path=output_dir_path,
+        output_path=f"./{test_dir}",
     )
+    output_file_path = f"./{test_dir}/kraken2_output.txt"
     assert hash.unordered(output_file_path) == KRAKEN2_OUTPUT_VIRAL_HASH
 
 
 def run_and_test_bowtie2_on_updated_db(
         expected_hash,
         output_dir_path,
-        update_db_output,
+        toolchest_output,
 ):
     """Tests a Bowtie 2 run on the updated DB."""
     output_file_path = f"{output_dir_path}/bowtie2_output.sam"
@@ -158,8 +160,8 @@ def run_and_test_bowtie2_on_updated_db(
     toolchest.bowtie2(
         inputs="s3://toolchest-integration-tests/bowtie2/fruitfly-ncbi/GSM868349.fastq.gz",
         output_path=output_dir_path,
-        database_name=update_db_output.database_name,
-        database_version=update_db_output.database_version,
+        database_name=toolchest_output.database_name,
+        database_version=toolchest_output.database_version,
     )
     filter_output.filter_sam(output_file_path, filtered_output_file_path)
     assert hash.unordered(filtered_output_file_path) == expected_hash

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -1142,9 +1142,9 @@ def update_database(database_path, tool, database_name, database_primary_name=No
     :param database_path: Path or list of paths (local or S3) to be passed in as inputs.
     :param tool: Toolchest tool with which you use the database (e.g. toolchest.tools.Kraken2).
     :param database_name: Name of database to update.
-    :param database_primary_name: Name or path of the file/prefix that will be passed as the database,
-        just like the command line call. Use `database_primary_name=None` to pass the entire *directory*
-        of files as the database. If left unspecified, assumes the primary name of the previous version.
+    :param database_primary_name: Base name of the file/prefix that would normally be passed in
+        to the command line call. If left unspecified, assumes the primary name of the previous
+        version.
     :param is_async: Whether to run the database addition asynchronously. Unlike tool runs,
         this is set to `True` by default.
 
@@ -1152,9 +1152,10 @@ def update_database(database_path, tool, database_name, database_primary_name=No
 
         >>> import toolchest_client as toolchest
         >>> toolchest.update_database(
-        ...     database_path="s3://toolchest-fsx-databases/kraken2/k2_viral_20210517/",
-        ...     tool=toolchest.tools.kraken2,
-        ...     database_name="standard",
+        ...     database_path="s3://toolchest-public-examples-no-encryption/integration-test-db/bowtie2-fruitfly",
+        ...     tool=toolchest.tools.Bowtie2,
+        ...     database_name="my_new_database",
+        ...     database_primary_name="Dmel_A4_1.0",
         ... )
 
     """
@@ -1200,8 +1201,8 @@ def add_database(database_path, tool, database_name, database_primary_name, is_a
     :param database_path: Path or list of paths (local or S3) to be passed in as inputs.
     :param tool: Toolchest tool with which you use the database (e.g. toolchest.tools.Kraken2).
     :param database_name: Name of the new database.
-    :param database_primary_name: Name or path of the file/prefix that will be passed as the database,
-        just like the command line call. Use `database_primary_name=None` to pass the entire *directory*
+    :param database_primary_name: Base name of the file/prefix that would normally be passed in
+        to the command line call. Use `database_primary_name=None` to pass the entire *directory*
         of files as the database.
     :param is_async: Whether to run the database addition asynchronously. Unlike tool runs,
         this is set to `True` by default.
@@ -1210,9 +1211,10 @@ def add_database(database_path, tool, database_name, database_primary_name, is_a
 
         >>> import toolchest_client as toolchest
         >>> toolchest.add_database(
-        ...     database_path="s3://toolchest-fsx-databases/kraken2/k2_viral_20210517/",
-        ...     tool=toolchest.tools.Kraken2,
+        ...     database_path="s3://toolchest-public-examples-no-encryption/integration-test-db/bowtie2-fruitfly",
+        ...     tool=toolchest.tools.Bowtie2,
         ...     database_name="my_new_database",
+        ...     database_primary_name="Dmel_A4_1.0",
         ... )
 
     """

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -1142,10 +1142,9 @@ def update_database(database_path, tool, database_name, database_primary_name=No
     :param database_path: Path or list of paths (local or S3) to be passed in as inputs.
     :param tool: Toolchest tool with which you use the database (e.g. toolchest.tools.Kraken2).
     :param database_name: Name of database to update.
-    :param database_primary_name: Name or path of the file to use as the primary database file
-        (i.e., what you would pass into the command line as the database), if uploading multiple
-        files. If unspecified, assumes that the *directory* of files is what will be passed in
-        as the database.
+    :param database_primary_name: Name or path of the file/prefix that will be passed as the database,
+        just like the command line call. Use `database_primary_name=None` to pass the entire *directory*
+        of files as the database. If left unspecified, assumes the primary name of the previous version.
     :param is_async: Whether to run the database addition asynchronously. Unlike tool runs,
         this is set to `True` by default.
 
@@ -1178,7 +1177,7 @@ def update_database(database_path, tool, database_name, database_primary_name=No
     return output
 
 
-def add_database(database_path, tool, database_name, database_primary_name=None, is_async=True, **kwargs):
+def add_database(database_path, tool, database_name, database_primary_name, is_async=True, **kwargs):
     """Adds a custom database and attaches it to a tool.
     The new database version is returned immediately after initialization.
 
@@ -1201,10 +1200,9 @@ def add_database(database_path, tool, database_name, database_primary_name=None,
     :param database_path: Path or list of paths (local or S3) to be passed in as inputs.
     :param tool: Toolchest tool with which you use the database (e.g. toolchest.tools.Kraken2).
     :param database_name: Name of the new database.
-    :param database_primary_name: Name or path of the file to use as the primary database file
-        (i.e., what you would pass into the command line as the database), if uploading multiple
-        files. If unspecified, assumes that the *directory* of files is what will be passed in
-        as the database.
+    :param database_primary_name: Name or path of the file/prefix that will be passed as the database,
+        just like the command line call. Use `database_primary_name=None` to pass the entire *directory*
+        of files as the database.
     :param is_async: Whether to run the database addition asynchronously. Unlike tool runs,
         this is set to `True` by default.
 

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -1202,8 +1202,8 @@ def add_database(database_path, tool, database_name, database_primary_name, is_a
     :param tool: Toolchest tool with which you use the database (e.g. toolchest.tools.Kraken2).
     :param database_name: Name of the new database.
     :param database_primary_name: Base name of the file/prefix that would normally be passed in
-        to the command line call. Use `database_primary_name=None` to pass the entire *directory*
-        of files as the database.
+        to the command line call. Use `database_primary_name=None` to use the directory name
+        as the database.
     :param is_async: Whether to run the database addition asynchronously. Unlike tool runs,
         this is set to `True` by default.
 

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -109,22 +109,6 @@ class Tool:
             raise ValueError(f"Too many input files submitted. "
                              f"Maximum is {self.max_inputs}, {self.num_input_files} found.")
 
-        # If this is a database update, sanitizes database_primary_name argument to just the filename, if specified.
-        # Note: if compress_inputs is True, this won't check against all input names, and behavior will be undefined
-        if self.is_database_update:
-            if self.database_primary_name:
-                self.database_primary_name = os.path.basename(self.database_primary_name)
-                # Sanitize database_primary_name if all files are local
-                # (If there is an S3 URI, it could be a prefix, so we skip overwriting database_primary_name)
-                if not any(path_is_s3_uri(input_path) for input_path in self.input_files):
-                    # If only one input file exists, use that file explicitly as the DB
-                    if self.num_input_files == 1 and not self.compress_inputs:
-                        self.database_primary_name = os.path.basename(self.input_files[0])
-                    # If DB name isn't a prefix for an input file, (implicitly) use directory of inputs instead as DB
-                    input_basenames = [os.path.basename(input_path) for input_path in self.input_files]
-                    if all([self.database_primary_name not in basename for basename in input_basenames]):
-                        self.database_primary_name = None
-
     def _output_path_is_local(self):
         return isinstance(self.output_path, str) and not path_is_s3_uri(self.output_path)
 

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -115,7 +115,8 @@ class Tool:
             if self.database_primary_name:
                 self.database_primary_name = os.path.basename(self.database_primary_name)
                 # If only one input file exists, use that file explicitly as the DB
-                if self.num_input_files == 1 and not self.compress_inputs:
+                # (If it is an S3 URI, it could be a prefix, so we skip overwriting database_primary_name)
+                if self.num_input_files == 1 and not self.compress_inputs and not path_is_s3_uri(self.input_files[0]):
                     self.database_primary_name = os.path.basename(self.input_files[0])
                 # If DB name isn't a prefix for an input file, (implicitly) use directory of inputs instead as DB
                 input_basenames = [os.path.basename(input_path) for input_path in self.input_files]

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -114,14 +114,16 @@ class Tool:
         if self.is_database_update:
             if self.database_primary_name:
                 self.database_primary_name = os.path.basename(self.database_primary_name)
-                # If only one input file exists, use that file explicitly as the DB
-                # (If it is an S3 URI, it could be a prefix, so we skip overwriting database_primary_name)
-                if self.num_input_files == 1 and not self.compress_inputs and not path_is_s3_uri(self.input_files[0]):
-                    self.database_primary_name = os.path.basename(self.input_files[0])
-                # If DB name isn't a prefix for an input file, (implicitly) use directory of inputs instead as DB
-                input_basenames = [os.path.basename(input_path) for input_path in self.input_files]
-                if all([self.database_primary_name not in basename for basename in input_basenames]):
-                    self.database_primary_name = None
+                # Sanitize database_primary_name if all files are local
+                # (If there is an S3 URI, it could be a prefix, so we skip overwriting database_primary_name)
+                if not any(path_is_s3_uri(input_path) for input_path in self.input_files):
+                    # If only one input file exists, use that file explicitly as the DB
+                    if self.num_input_files == 1 and not self.compress_inputs:
+                        self.database_primary_name = os.path.basename(self.input_files[0])
+                    # If DB name isn't a prefix for an input file, (implicitly) use directory of inputs instead as DB
+                    input_basenames = [os.path.basename(input_path) for input_path in self.input_files]
+                    if all([self.database_primary_name not in basename for basename in input_basenames]):
+                        self.database_primary_name = None
 
     def _output_path_is_local(self):
         return isinstance(self.output_path, str) and not path_is_s3_uri(self.output_path)


### PR DESCRIPTION
* Adds an integration test for a custom database update with an S3 prefix as input and an auto-generated `database_primary_name`.
* Modifies function call for `add_database_update` to mandate `database_primary_name`.
* Removes `database_primary_name` sanitization.
* Increases CI parallelism to 8.