### PR TITLE
feat: add GPU instance type (TC-28)

### DIFF
--- a/toolchest_client/api/instance_type.py
+++ b/toolchest_client/api/instance_type.py
@@ -28,3 +28,5 @@ class InstanceType(Enum):
     MEMORY_256 = "memory-256"
     MEMORY_384 = "memory-384"
     MEMORY_512 = "memory-512"
+    # GPU instances, lists core GPU type
+    GPU_V100 = "gpu-V100"


### PR DESCRIPTION
Adds:
- GPU instance type (matching internal GPU instance type)

Manually tested previously with Lug, but opting not to add an integration test for GPU instances. Open to adding a test.