### PR TITLE
feat: add docker upload progress log (TC-60)

### DIFF
--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -386,7 +386,7 @@ class Query:
                 # Print doesn't work on some consoles, like the JetBrains suite
                 sys.stdout.write(
                     "\r{} {}".format(
-                        update.get("status"),
+                        update.get("status", ""),
                         update.get("progress", ""),
                     ).ljust(120),
                 )

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -336,7 +336,7 @@ class Query:
         except ImageNotFound:
             raise ToolchestException(f"Unable to find image {custom_docker_image_id}.")
         except (APIError, DockerException):
-            raise EnvironmentError('Unable to connect to Docker. Make sure yoe have docker installed and that it is '
+            raise EnvironmentError('Unable to connect to Docker. Make sure you have docker installed and that it is '
                                    'currently running.')
         register_input_file_url = "/".join([
             self.PIPELINE_SEGMENT_INSTANCE_URL,
@@ -374,9 +374,23 @@ class Query:
             docker_image_name_and_tag = custom_docker_image_id.split(':')
             docker_tag = docker_image_name_and_tag[1] if len(docker_image_name_and_tag) > 1 else 'latest'
             image.tag(f"{registry}/{aws_info['repository_name']}:{docker_tag}", docker_tag)
-            push_output = client.api.push(f"{registry}/{aws_info['repository_name']}:{docker_tag}", docker_tag)
-            if 'errorDetail' in push_output:
-                raise ToolchestJobError("Failed to push image.")
+            push_output = client.api.push(
+                f"{registry}/{aws_info['repository_name']}:{docker_tag}",
+                tag=docker_tag,
+                stream=True,
+                decode=True,
+            )
+            for update in push_output:
+                if 'errorDetail' in update:
+                    raise ToolchestJobError("Failed to push image.")
+                # Print doesn't work on some consoles, like the JetBrains suite
+                sys.stdout.write(
+                    "\r{} {}".format(
+                        update.get("status"),
+                        update.get("progress", ""),
+                    ).ljust(120),
+                )
+                sys.stdout.flush()
         except APIError:
             raise EnvironmentError('Unable to access ECR at this time. '
                                    'Contact Toolchest support if this error persists')

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -362,8 +362,6 @@ class Tool:
             if uploading:
                 time.sleep(5)
 
-        print("Finished spawning jobs.")
-
     def _generate_jobs(self, should_run_in_parallel):
         """Generates staggered jobs for both parallel and non-parallel runs.
 
@@ -478,7 +476,6 @@ class Tool:
             self.query_threads.append(new_thread)
             self.query_thread_statuses[new_thread.getName()] = ThreadStatus.INITIALIZING
 
-            print(f"Spawning job #{len(self.query_threads)}...")
             new_thread.start()
 
         self._wait_for_threads_to_finish()


### PR DESCRIPTION
Adds a progress bar that looks like:

```
Pushing [=>                                                 ]  166.2MB/5.831GB 
```

Instead of giving the standard Docker-style updates on multiple lines, this just overwrites the most recent line to give rough progress.