### PR TITLE
feat: add support for public images in dockerhub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.9.43"
+version = "0.11.0"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bryce@trytoolchest.com>",

--- a/tests/test_python3.py
+++ b/tests/test_python3.py
@@ -63,3 +63,24 @@ def test_python3_with_docker():
     assert output_file.readline() == "[[ 58  64]\n"
     assert output_file.readline() == " [139 154]]"
     output_file.close()
+
+
+@pytest.mark.integration
+def test_python3_with_public_docker():
+    """
+    Tests using a public docker image with the write test script
+    """
+
+    test_dir = "./temp_test_python3/with_public_docker"
+    os.makedirs(f"{test_dir}", exist_ok=True)
+    toolchest.python3(
+        tool_args="./input/example.fastq",
+        script="s3://toolchest-integration-tests/write_test.py",
+        inputs="s3://toolchest-integration-tests/example.fastq",
+        output_path=f"{test_dir}/",
+        custom_docker_image_id="python:alpine3.16",
+    )
+
+    output_file = open(f"{test_dir}/output.txt", "r")
+    assert output_file.readline() == "Success"
+    output_file.close()

--- a/tests/test_python3.py
+++ b/tests/test_python3.py
@@ -74,7 +74,6 @@ def test_python3_with_public_docker():
     test_dir = "./temp_test_python3/with_public_docker"
     os.makedirs(f"{test_dir}", exist_ok=True)
     toolchest.python3(
-        tool_args="",
         script="s3://toolchest-integration-tests/write_path.py",
         output_path=f"{test_dir}/",
         custom_docker_image_id="python:alpine3.16",

--- a/tests/test_python3.py
+++ b/tests/test_python3.py
@@ -74,13 +74,14 @@ def test_python3_with_public_docker():
     test_dir = "./temp_test_python3/with_public_docker"
     os.makedirs(f"{test_dir}", exist_ok=True)
     toolchest.python3(
-        tool_args="./input/example.fastq",
-        script="s3://toolchest-integration-tests/write_test.py",
-        inputs="s3://toolchest-integration-tests/example.fastq",
+        tool_args="",
+        script="s3://toolchest-integration-tests/write_path.py",
         output_path=f"{test_dir}/",
         custom_docker_image_id="python:alpine3.16",
     )
 
     output_file = open(f"{test_dir}/output.txt", "r")
-    assert output_file.readline() == "Success"
+    assert output_file.readline() == "['/data/home/ec2-user/input', '/usr/local/lib/python310.zip', " \
+                                     "'/usr/local/lib/python3.10', '/usr/local/lib/python3.10/lib-dynload', " \
+                                     "'/usr/local/lib/python3.10/site-packages']"
     output_file.close()

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -342,8 +342,9 @@ class Query:
         except ImageNotFound:
             return custom_docker_image_id
         except (APIError, DockerException):
-            raise EnvironmentError('Unable to connect to Docker. Make sure you have docker installed and that it is '
-                                   'currently running.')
+            print('Unable to connect to Docker. Assuming image is accessible in a registry. If the image is hosted '
+                  'locally start Docker and retry.')
+            return custom_docker_image_id
         register_input_file_url = "/".join([
             self.PIPELINE_SEGMENT_INSTANCE_URL,
             'docker-image'

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -16,7 +16,7 @@ import boto3
 import requests
 import docker
 from requests.exceptions import HTTPError
-from docker.errors import ImageNotFound, DockerException, APIError, NotFound
+from docker.errors import ImageNotFound, DockerException, APIError
 
 from toolchest_client.api.auth import get_headers
 from toolchest_client.api.download import download, get_download_details

--- a/toolchest_client/api/query.py
+++ b/toolchest_client/api/query.py
@@ -16,7 +16,7 @@ import boto3
 import requests
 import docker
 from requests.exceptions import HTTPError
-from docker.errors import ImageNotFound, DockerException, APIError
+from docker.errors import ImageNotFound, DockerException, APIError, NotFound
 
 from toolchest_client.api.auth import get_headers
 from toolchest_client.api.download import download, get_download_details
@@ -108,7 +108,7 @@ class Query:
         self.thread_name = threading.current_thread().getName()
         self.thread_statuses = thread_statuses
         self._check_if_should_terminate()
-
+        docker_image_id = self._upload_docker_image(custom_docker_image_id)
         # Create pipeline segment and task(s).
         # Retrieve query ID and upload URL from initial response.
         create_response = self._send_initial_request(
@@ -117,7 +117,7 @@ class Query:
             database_version=database_version,
             remote_database_path=remote_database_path,
             remote_database_primary_name=remote_database_primary_name,
-            custom_docker_image_id=custom_docker_image_id,
+            custom_docker_image_id=docker_image_id,
             is_database_update=is_database_update,
             database_primary_name=database_primary_name,
             tool_name=tool_name,
@@ -156,7 +156,6 @@ class Query:
         self._check_if_should_terminate()
         self._update_thread_status(ThreadStatus.UPLOADING)
         self._upload(input_files, input_prefix_mapping, input_is_compressed)
-        self._upload_docker_image(custom_docker_image_id)
         self._check_if_should_terminate()
 
         self._update_thread_status(ThreadStatus.EXECUTING)
@@ -336,12 +335,12 @@ class Query:
 
     def _upload_docker_image(self, custom_docker_image_id):
         if custom_docker_image_id is None:
-            return
+            return None
         try:  # Try to get the image before creating a repository.
             client = docker.from_env()
             image = client.images.get(custom_docker_image_id)
         except ImageNotFound:
-            raise ToolchestException(f"Unable to find image {custom_docker_image_id}.")
+            return custom_docker_image_id
         except (APIError, DockerException):
             raise EnvironmentError('Unable to connect to Docker. Make sure you have docker installed and that it is '
                                    'currently running.')
@@ -380,9 +379,10 @@ class Query:
             )
             docker_image_name_and_tag = custom_docker_image_id.split(':')
             docker_tag = docker_image_name_and_tag[1] if len(docker_image_name_and_tag) > 1 else 'latest'
-            image.tag(f"{registry}/{aws_info['repository_name']}:{docker_tag}", docker_tag)
+            image_id = f"{registry}/{aws_info['repository_name']}:{docker_tag}"
+            image.tag(image_id, docker_tag)
             push_output = client.api.push(
-                f"{registry}/{aws_info['repository_name']}:{docker_tag}",
+                image_id,
                 tag=docker_tag,
                 stream=True,
                 decode=True,
@@ -401,6 +401,7 @@ class Query:
         except APIError:
             raise EnvironmentError('Unable to access ECR at this time. '
                                    'Contact Toolchest support if this error persists')
+        return image_id
 
     def _update_thread_status(self, new_status):
         """


### PR DESCRIPTION
This pr assumes if an image isn't found locally that it's a public image on dockerhub. A local image is still used if a matching one is found even if a public dockerhub image of the same name and tag exists. If no local or public image exists it will fail during execution instead of during the pre-execution client steps.