### PR TITLE
feat: switch docker_tag to version_tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.11.0"
+version = "0.11.1"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bryce@trytoolchest.com>",

--- a/toolchest_client/tools/api.py
+++ b/toolchest_client/tools/api.py
@@ -506,16 +506,16 @@ provided.
 
 
 def jupyter(notebook, inputs=None, output_path=None, requirements=None,
-            docker_tag="latest", grace_period_seconds=None, port=None, **kwargs):
+            version_tag="latest", grace_period_seconds=None, port=None, **kwargs):
     """Get a spawn token for a Jamsocket Jupyter notebook environment via toolchest.
 
     :param notebook: path to the Jupyter Notebook to run on environment start.
     :param inputs: (optional) path(s) to the files that will be accessible in the spawned environment. Additional
     Jupyter Notebooks can be provided here.
     :param requirements: (optional) path to a pip requirements.txt file to install dependencies for the notebook
-    environement.
+    environment.
     :param output_path: (optional) local path to where the output file(s) will be downloaded.
-    :param docker_tag: (optional) the docker tag used to version the notebook env. "latest" will be used if a tag is
+    :param version_tag: (optional) the docker tag used to version the notebook env. "latest" will be used if a tag is
     not provided.
     :param grace_period_seconds: (optional) grace period (in seconds) to wait after last connection is closed before
     shutting down the notebook
@@ -527,15 +527,15 @@ def jupyter(notebook, inputs=None, output_path=None, requirements=None,
         ...     inputs=["./path/to/file.txt", "./path/to/other_notebook.ipynb"],
         ...     requirements="./path/to/requirements.txt",
         ...     output_path="./path/to/local/output/",
-        ...     docker_tag="v1",
+        ...     version_tag="v1",
         ...     grace_period_seconds="300",
         ...     port="8080",
         ... )
     """
     tool_args = {
-        "docker-tag": docker_tag,
+        "docker-tag": version_tag,
         "jamsocket-args": {
-            "tag": docker_tag,
+            "tag": version_tag,
         }
     }
     if grace_period_seconds is not None:


### PR DESCRIPTION
Leaves `tool_args` the same as that would require a worker node pr and isn't exposed publicly.