### PR TITLE
chore: fix centrifuge docs bullets, blacklist

### DIFF
--- a/docs/docs/tool-reference/taxonomic-classifiers/centrifuge.md
+++ b/docs/docs/tool-reference/taxonomic-classifiers/centrifuge.md
@@ -81,30 +81,30 @@ Supported Additional Arguments
 ==============================
 
 Most additional arguments not related to input, output, or multithreading are supported:
-- \-q
-- \--qseq
-- \-f
-- \-r
-- \-c
-- \-s, \--skip
-- \-u, \--upto
-- \-5, \--trim5
-- \-3, \--trim3
-- \--phred33
-- \--phred64
-- \--int-quals
-- \--ignore-quals
-- \--nofw
-- \--norc
-- \--min-hitlen
-- \-k
-- \--host-taxids
-- \--exclude-taxids
-- \--out-fmt
-- \--tab-fmt-cols
-- \-t, \--time
-- \--qc-filter
-- \--seed
-- \--non-deterministic
 
-Additional arguments can be specified under the `tool_args` argument.
+- `-q`
+- `--qseq`
+- `-f`
+- `-r`
+- `-s`, `--skip`
+- `-u`, `--upto`
+- `-5`, `--trim5`
+- `-3`, `--trim3`
+- `--phred33`
+- `--phred64`
+- `--int-quals`
+- `--ignore-quals`
+- `--nofw`
+- `--norc`
+- `--min-hitlen`
+- `-k`
+- `--host-taxids`
+- `--exclude-taxids`
+- `--out-fmt`
+- `--tab-fmt-cols`
+- `-t`, `--time`
+- `--qc-filter`
+- `--seed`
+- `--non-deterministic`
+
+Set additional arguments with `tool_args`. For example: `tool_args="-f -k 10"`

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -58,7 +58,7 @@ nav:
           - About Structure Prediction: "tool-reference/structure-prediction.md"
           - AlphaFold: "tool-reference/structure-prediction/alphafold.md"
       - Taxonomic Classifiers:
-          - About Taxanomic Classifiers: "tool-reference/taxonomic-classifiers.md"
+          - About Taxonomic Classifiers: "tool-reference/taxonomic-classifiers.md"
           - Centrifuge: "tool-reference/taxonomic-classifiers/centrifuge.md"
           - Kraken 2: "tool-reference/taxonomic-classifiers/kraken-2.md"
           - MetaPhlAn: "tool-reference/taxonomic-classifiers/metaphlan.md"

--- a/toolchest_client/tools/tool_args.py
+++ b/toolchest_client/tools/tool_args.py
@@ -212,6 +212,7 @@ TOOL_ARG_LISTS = {
             "*": 0
         },
         "blacklist": [
+            "-c",
             "-S",
             "-p",
             "--threads",


### PR DESCRIPTION
Fixes typos/formatting in the `centrifuge` docs page, and adds an unsupported argument to the `centrifuge` blacklist.