### PR TITLE
feat: retain directory structure for compressed inputs

### DIFF
--- a/docs/docs/getting-started/using-files.md
+++ b/docs/docs/getting-started/using-files.md
@@ -17,9 +17,32 @@ Let's take a look at what it looks like to use different types of local and remo
 Local files are the most intuitive: you just pass normal paths directly to Toolchest. In the background, the files are 
 transferred to and from the cloud.
 
-`inputs` takes files or directories. If a directory is passed, all files within the directory are used as input.
+`inputs` takes file or directory path(s).
 
 `output_path` takes a directory. Output files are written in this directory.
+
+### Local directory inputs
+If a directory is passed, all files within the directory are used as input. Directory structure will be destroyed unless
+`compress_inputs=True` is provided as an argument.
+
+For example if you have the following directory structure:
+```text
+/path/to/base/directory/
+    subdirectory_one/
+        input.fastq
+    subdirectory_two/
+        input.fastq
+        info.txt
+```
+and you used the following toolchest call:
+```python
+tc.test(
+    inputs="/path/to/base/directory/",
+    compress_inputs=True
+)
+```
+Then the input files will retain the directory structure without name conflicts. If `compress_inputs` is set to `False`
+or not provided, the 2 `inputs.fastq` would overwrite whichever one was downloaded second. 
 
 ## Remote files
 

--- a/docs/docs/getting-started/using-files.md
+++ b/docs/docs/getting-started/using-files.md
@@ -17,9 +17,9 @@ Let's take a look at what it looks like to use different types of local and remo
 Local files are the most intuitive: you just pass normal paths directly to Toolchest. In the background, the files are 
 transferred to and from the cloud.
 
-`inputs` takes file or directory path(s).
+`inputs` takes file and/or directory path(s).
 
-`output_path` takes a directory. Output files are written in this directory.
+`output_path` takes a path to a directory. Output files are written in this directory.
 
 ### Local directory inputs
 If a directory is passed, all files within the directory are used as input. Directory structure will be destroyed unless

--- a/docs/docs/getting-started/using-files.md
+++ b/docs/docs/getting-started/using-files.md
@@ -17,7 +17,7 @@ Let's take a look at what it looks like to use different types of local and remo
 Local files are the most intuitive: you just pass normal paths directly to Toolchest. In the background, the files are 
 transferred to and from the cloud.
 
-`inputs` takes file and/or directory path(s).
+`inputs` takes paths to files and directories.
 
 `output_path` takes a path to a directory. Output files are written in this directory.
 

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -102,11 +102,9 @@ class Tool:
                 self.inputs = [self.inputs]
             for input_path in self.inputs:
                 if path_is_s3_uri(input_path):
-                    # If the given path is in S3, it does not require compression.
                     self.input_files += [files_in_path(input_path)]
-                    # self.compress_inputs = False
                 elif os.path.isfile(input_path):
-                    self.input_files += [input_path]
+                    self.input_files += [files_in_path(input_path)]
                 else:
                     # Input files are all .tar.gz'd together, preserving directory structure
                     self.input_files += [compress_files_in_path(os.path.expanduser(input_path))]


### PR DESCRIPTION
May be worth renaming `compress_inputs` to `retain_directories` or similar in the future. It's only really used for that now.