### PR TITLE
v0.11.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           name: Skip tests if last commit is a chore commit
           command: |      
             cd ~/repo
-            last_commit="$(git log -1 --pretty=%B | grep chore || true)"
+            last_commit="$(git log -1 --pretty=%s | grep chore: || true)"
             if [ ${#last_commit} -gt 0 ]; then circleci-agent step halt; fi
       - run:
           name: Create AWS credentials manually

--- a/docs/docs/getting-started/using-files.md
+++ b/docs/docs/getting-started/using-files.md
@@ -17,9 +17,32 @@ Let's take a look at what it looks like to use different types of local and remo
 Local files are the most intuitive: you just pass normal paths directly to Toolchest. In the background, the files are 
 transferred to and from the cloud.
 
-`inputs` takes files or directories. If a directory is passed, all files within the directory are used as input.
+`inputs` takes paths to files and directories.
 
-`output_path` takes a directory. Output files are written in this directory.
+`output_path` takes a path to a directory. Output files are written in this directory.
+
+### Local directory inputs
+If a directory is passed, all files within the directory are used as input. Directory structure will be destroyed unless
+`compress_inputs=True` is provided as an argument.
+
+For example if you have the following directory structure:
+```text
+/path/to/base/directory/
+    subdirectory_one/
+        input.fastq
+    subdirectory_two/
+        input.fastq
+        info.txt
+```
+and you used the following toolchest call:
+```python
+tc.test(
+    inputs="/path/to/base/directory/",
+    compress_inputs=True
+)
+```
+Then the input files will retain the directory structure without name conflicts. If `compress_inputs` is set to `False`
+or not provided, the 2 `inputs.fastq` would overwrite whichever one was downloaded second. 
 
 ## Remote files
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toolchest-client"
-version = "0.11.3"
+version = "0.11.4"
 description = "Python client for Toolchest"
 authors = [
     "Bryce Cai <bryce@trytoolchest.com>",

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -96,19 +96,21 @@ class Tool:
 
     def _prepare_inputs(self):
         """Prepares the input files."""
-        if self.compress_inputs and isinstance(self.inputs, str):
-            if path_is_s3_uri(self.inputs):
-                # If the given path is in S3, it does not require compression.
-                self.input_files = [self.inputs]
-                self.compress_inputs = False
-            else:
-                # Input files are all .tar.gz'd together, preserving directory structure
-                self.input_files = [compress_files_in_path(os.path.expanduser(self.inputs))]
-            self.num_input_files = 1
+        if self.compress_inputs:
+            self.input_files = []
+            if isinstance(self.inputs, str):
+                self.inputs = [self.inputs]
+            for input_path in self.inputs:
+                if path_is_s3_uri(input_path):
+                    self.input_files += [files_in_path(input_path)]
+                elif os.path.isfile(input_path):
+                    self.input_files += [files_in_path(input_path)]
+                else:
+                    # Input files are all .tar.gz'd together, preserving directory structure
+                    self.input_files += [compress_files_in_path(os.path.expanduser(input_path))]
+            self.num_input_files = len(self.input_files)
         else:
-            # TODO: compress inputs in cases where inputs is a list
-            self.compress_inputs = False
-            # Input files are handled individually, destroying directory structure
+            # Non compressed files are handled individually, destroying directory structure
             self.input_files = files_in_path(self.inputs)  # expands ~ in filepath if local
             self.num_input_files = len(self.input_files)
 

--- a/toolchest_client/tools/tool.py
+++ b/toolchest_client/tools/tool.py
@@ -102,9 +102,9 @@ class Tool:
                 self.inputs = [self.inputs]
             for input_path in self.inputs:
                 if path_is_s3_uri(input_path):
-                    self.input_files += [files_in_path(input_path)]
+                    self.input_files += files_in_path(input_path)
                 elif os.path.isfile(input_path):
-                    self.input_files += [files_in_path(input_path)]
+                    self.input_files += files_in_path(input_path)
                 else:
                     # Input files are all .tar.gz'd together, preserving directory structure
                     self.input_files += [compress_files_in_path(os.path.expanduser(input_path))]


### PR DESCRIPTION
Adds:
- Way to retain directory structure for multiple inputs if `compress_inputs=True` arg is provided to Toolchest call.

Modifies:
- Input compression to only compress local directory inputs
